### PR TITLE
Fix #70: iOS: createActivation error userInfo propagation

### DIFF
--- a/proj-xcode/Classes/sdk/PowerAuthSDK.m
+++ b/proj-xcode/Classes/sdk/PowerAuthSDK.m
@@ -571,12 +571,12 @@ static PowerAuthSDK *inst;
 					activationResult.customAttributes = responseObject.customAttributes;
 				} else {
 					// Error occurred
-                    printf("error 1")
+                    printf("error 1");
 					errorToReport = [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeInvalidActivationData userInfo:nil];
 				}
 			} else {
 				// Activation error occurred
-                printf("error 2")
+                printf("error 2");
 				errorToReport = [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeInvalidActivationData userInfo:nil];
 			}
 		}

--- a/proj-xcode/Classes/sdk/PowerAuthSDK.m
+++ b/proj-xcode/Classes/sdk/PowerAuthSDK.m
@@ -575,7 +575,6 @@ static PowerAuthSDK *inst;
 				}
 			} else {
 				// Activation error occurred
-                PALog(@"error 2");
                 NSDictionary *encryptedResponseDictionary = [NSJSONSerialization JSONObjectWithData:httpData options:kNilOptions error:nil];
 				errorToReport = [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeInvalidActivationData userInfo:encryptedResponseDictionary];
 			}

--- a/proj-xcode/Classes/sdk/PowerAuthSDK.m
+++ b/proj-xcode/Classes/sdk/PowerAuthSDK.m
@@ -571,10 +571,12 @@ static PowerAuthSDK *inst;
 					activationResult.customAttributes = responseObject.customAttributes;
 				} else {
 					// Error occurred
+                    printf("error 1")
 					errorToReport = [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeInvalidActivationData userInfo:nil];
 				}
 			} else {
 				// Activation error occurred
+                printf("error 2")
 				errorToReport = [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeInvalidActivationData userInfo:nil];
 			}
 		}

--- a/proj-xcode/Classes/sdk/PowerAuthSDK.m
+++ b/proj-xcode/Classes/sdk/PowerAuthSDK.m
@@ -571,18 +571,15 @@ static PowerAuthSDK *inst;
 					activationResult.customAttributes = responseObject.customAttributes;
 				} else {
 					// Error occurred
-                    PALog(@"error 1");
 					errorToReport = [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeInvalidActivationData userInfo:nil];
 				}
 			} else {
 				// Activation error occurred
                 PALog(@"error 2");
-				errorToReport = [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeInvalidActivationData userInfo:nil];
+                NSDictionary *encryptedResponseDictionary = [NSJSONSerialization JSONObjectWithData:httpData options:kNilOptions error:nil];
+				errorToReport = [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeInvalidActivationData userInfo:encryptedResponseDictionary];
 			}
-        } else {
-            PALog(@"error 3");
         }
-        
 		if (errorToReport) {
 			[_session resetSession];
 		}

--- a/proj-xcode/Classes/sdk/PowerAuthSDK.m
+++ b/proj-xcode/Classes/sdk/PowerAuthSDK.m
@@ -571,15 +571,18 @@ static PowerAuthSDK *inst;
 					activationResult.customAttributes = responseObject.customAttributes;
 				} else {
 					// Error occurred
-                    printf("error 1");
+                    PALog(@"error 1");
 					errorToReport = [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeInvalidActivationData userInfo:nil];
 				}
 			} else {
 				// Activation error occurred
-                printf("error 2");
+                PALog(@"error 2");
 				errorToReport = [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeInvalidActivationData userInfo:nil];
 			}
-		}
+        } else {
+            PALog(@"error 3");
+        }
+        
 		if (errorToReport) {
 			[_session resetSession];
 		}


### PR DESCRIPTION
@hvge We can merge this change as a hotfix - it is pretty minor. I believe the proper fix would be using the more high-level `postToUrl:...` method of `PA2Client` that does similar work when serializing request/response objects.