### PR TITLE
IOS: Fixed #70: Hotfix for additional error info propagation when custom activation fails on the server

### DIFF
--- a/proj-xcode/Classes/core/PA2ErrorConstants.h
+++ b/proj-xcode/Classes/core/PA2ErrorConstants.h
@@ -56,3 +56,14 @@ extern NSInteger const PA2ErrorCodeOperationCancelled;
 
 /** Error code for errors related to end-to-end encryption */
 extern NSInteger const PA2ErrorCodeEncryption;
+
+/**
+ A key to NSError.userInfo dicionary where the optional NSDictionary with additional
+ information about error is stored.
+ */
+extern NSString * __nonnull const PA2ErrorInfoKey_AdditionalInfo;
+/**
+ A key to NSError.userInfo dicionary where the optional NSData with error response
+ is stored.
+ */
+extern NSString * __nonnull const PA2ErrorInfoKey_ResponseData;

--- a/proj-xcode/Classes/core/PA2ErrorConstants.m
+++ b/proj-xcode/Classes/core/PA2ErrorConstants.m
@@ -20,6 +20,8 @@
 
 /** PowerAuth SDK error domain */
 NSString *const PA2ErrorDomain					= @"PA2ErrorDomain";
+NSString *const PA2ErrorInfoKey_AdditionalInfo	= @"PA2ErrorInfoKey_AdditionalInfo";
+NSString *const PA2ErrorInfoKey_ResponseData	= @"PA2ErrorInfoKey_ResponseData";
 
 /** Error code for error with network connectivity or download */
 NSInteger const PA2ErrorCodeNetworkError				= (1);

--- a/proj-xcode/Classes/networking/client/PA2Client.m
+++ b/proj-xcode/Classes/networking/client/PA2Client.m
@@ -32,7 +32,7 @@
 	
 	NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*)response;
 	NSError *err = nil;
-	NSDictionary *responseDictionary = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&err];
+	NSDictionary *responseDictionary = !data ? nil : [NSJSONSerialization JSONObjectWithData:data options:0 error:&err];
 	
 	PA2ErrorResponse *httpResponseObject;
 	httpResponseObject.httpStatusCode = httpResponse.statusCode;
@@ -41,10 +41,13 @@
 	} else {
 		httpResponseObject = [[PA2ErrorResponse alloc] initWithDictionary:responseDictionary];
 	}
-	
-	NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
-	[dictionary setObject:httpResponseObject forKey:PA2ErrorDomain];
-	return [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeNetworkError userInfo:dictionary];
+	NSDictionary * additionalInfo =
+  	@{
+		PA2ErrorDomain: 				httpResponseObject,
+		PA2ErrorInfoKey_AdditionalInfo: responseDictionary ? responseDictionary : @{},
+		PA2ErrorInfoKey_ResponseData: 	data ? data : [NSData data]
+	 };
+	return [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeNetworkError userInfo:additionalInfo];
 }
 
 /** Build absolute URL for given resource using given base URL.

--- a/proj-xcode/Classes/sdk/PowerAuthSDK.m
+++ b/proj-xcode/Classes/sdk/PowerAuthSDK.m
@@ -538,9 +538,12 @@ static PowerAuthSDK *inst;
 			if (encryptedResponse.status == PA2RestResponseStatus_OK) {
 				
 				NSData *decryptedResponseData = [encryptor decryptResponse:encryptedResponse error:nil];
-				NSDictionary *createActivationResponseDictionary = [NSJSONSerialization JSONObjectWithData:decryptedResponseData
-																								   options:kNilOptions
-																									 error:nil];
+				NSDictionary *createActivationResponseDictionary;
+				if (decryptedResponseData) {
+					createActivationResponseDictionary = [NSJSONSerialization JSONObjectWithData:decryptedResponseData options:0 error:nil];
+				} else {
+					createActivationResponseDictionary = nil;
+				}
 				
 				PA2CreateActivationResponse *responseObject = [[PA2CreateActivationResponse alloc] initWithDictionary:createActivationResponseDictionary];
 				
@@ -564,8 +567,18 @@ static PowerAuthSDK *inst;
 					errorToReport = [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeInvalidActivationData userInfo:nil];
 				}
 			} else {
-				// Activation error occurred
-				errorToReport = [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeInvalidActivationData userInfo:nil];
+				// Activation error occurred, propagate response data to the error object
+				// Try to parse response data as JSON
+				// TODO: needs to be hardened with PA2ObjectAs() once we merge token-branch...
+				NSDictionary * responseJson = httpData ? [NSJSONSerialization JSONObjectWithData:httpData options:kNilOptions error:nil] : nil;
+				NSMutableDictionary * additionalInfo = [NSMutableDictionary dictionaryWithCapacity:2];
+				if (httpData) {
+					additionalInfo[PA2ErrorInfoKey_ResponseData] = httpData;
+				}
+				if (responseJson) {
+					additionalInfo[PA2ErrorInfoKey_AdditionalInfo] = responseJson;
+				}
+				errorToReport = [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeInvalidActivationData userInfo:additionalInfo];
 			}
 		}
 		if (errorToReport) {


### PR DESCRIPTION
This is similar change to #71 but with more safe data handling. In my implementation, the response dictionary is not set directly to the error's userInfo, but under the dedicated key (`PA2ErrorInfoKey_AdditionalInfo`). That's more traditional approach on IOS when error needs to keep an additional data.

I have also fixed other possible JSON deserializer crashes on nil data.