### PR TITLE
Core: Fixed #51: Added migration code from old persistent data format.

### DIFF
--- a/src/PowerAuth/Session.cpp
+++ b/src/PowerAuth/Session.cpp
@@ -163,9 +163,15 @@ namespace powerAuth
 		bool result = reader.openVersion(DATA_TAG, DATA_VER) &&
 					  reader.readByte(flags);
 		
-		if (flags & HAS_PERSISTENT_DATA) {
-			result = result && protocol::DeserializePersistentData(*new_data, reader);
-			has_data = result;
+		if (result && (flags != 'M')) {
+			if (flags & HAS_PERSISTENT_DATA) {
+				result = result && protocol::DeserializePersistentData(*new_data, reader);
+				has_data = result;
+			}
+		} else {
+			// DATA_MIGRATION_TAG
+			result = protocol::TryDeserializeOldPersistentData(*new_data, reader);
+			has_data = result && !new_data->activationId.empty();
 		}
 		
 		State new_state = has_data ? SS_Activated : SS_Empty;

--- a/src/PowerAuth/protocol/PrivateTypes.cpp
+++ b/src/PowerAuth/protocol/PrivateTypes.cpp
@@ -216,6 +216,101 @@ namespace protocol
 		
 		return result;
 	}
+	
+	// MARK: - Support for old data format -
+	
+	//
+	// For a historical reasons, we still have to support old persistent data format,
+	// which has been used in very old, closed source version, of PowerAuth library.
+	//
+	// Once all users will migrate to app based on our open source library, then this
+	// code will be removed.
+	//
+	// DATA_MIGRATION_TAG
+	
+	static bool _old_readData(utils::DataReader & reader, cc7::ByteArray & out_data, size_t expected_size = 0)
+	{
+		uint16_t size;
+		if (!reader.readU16(size)) {
+			return false;
+		}
+		if (expected_size > 0 && expected_size != size) {
+			return false;
+		}
+		if (!reader.readMemory(out_data, size)) {
+			return false;
+		}
+		return true;
+	}
+	
+	static bool _old_readString(utils::DataReader & reader, std::string & out_string)
+	{
+		uint16_t size;
+		if (!reader.readU16(size)) {
+			return false;
+		}
+		cc7::ByteRange range;
+		if (!reader.readMemoryRange(range, size)) {
+			return false;
+		}
+		out_string.assign((const char*)range.data(), range.size());
+		return true;
+	}
+
+	bool TryDeserializeOldPersistentData(PersistentData & pd, utils::DataReader & reader)
+	{
+		enum OldDataTags
+		{
+			// magic & length of header
+			H_1 = 'P', H_2 = 'A', H_3 = 'M',
+			H_SIZE = 4,
+			// supported versions
+			H_VER1 = '1', H_VER2 = '2',
+			// Activation or not...
+			H_ACT      = 'a',
+			H_NO_ACT   = 'i',
+			// End of records
+			H_END     = 0xff
+		};
+
+		// reset stream offset to the zero
+		reader.reset();
+
+		// read header
+		cc7::ByteRange header;
+		cc7::byte ver = 0, status = 0, end = 0;
+		cc7::U32 foo;
+		bool result = reader.readMemoryRange(header, H_SIZE) &&
+					  reader.readByte(status);
+		if (!result || header[0] != H_1 || header[1] != H_2 || header[2] != H_3) {
+			return false;	// unknown magic in header
+		}
+		ver = header[3];
+		if ((ver != H_VER1 && ver != H_VER2) || (status != H_ACT && status != H_NO_ACT)) {
+			return false;	// unknown version or status tag
+		}
+		if (status == H_ACT) {
+			// has activation, so deserialize persistent data
+			result = result && _old_readString(reader, pd.activationId);
+			result = result && reader.readU64(pd.signatureCounter);
+			result = result && reader.readU32(foo);	// ignore "flags", there's nothing important there
+			result = result && _old_readData(reader, pd.passwordSalt);
+			result = result && reader.readU32(pd.passwordIterations);
+			result = result && _old_readData(reader, pd.sk.possessionKey, SIGNATURE_KEY_SIZE);
+			result = result && _old_readData(reader, pd.sk.knowledgeKey, SIGNATURE_KEY_SIZE);
+			result = result && _old_readData(reader, pd.sk.biometryKey);
+			result = result && _old_readData(reader, pd.sk.transportKey, SIGNATURE_KEY_SIZE);
+			result = result && _old_readData(reader, pd.serverPublicKey);
+			result = result && _old_readData(reader, pd.cDevicePrivateKey);
+			if (ver == H_VER2) {
+				std::string foo;
+				result = result && _old_readString(reader, foo); // this value is no longer important
+			}
+			result = result && ValidatePersistentData(pd);
+		}
+		result = result && reader.readByte(end);
+		return   result && (end == H_END) && (reader.remainingSize() == 0);
+	}
 
 	
 } // io::getlime::powerAuth::detail

--- a/src/PowerAuth/protocol/PrivateTypes.h
+++ b/src/PowerAuth/protocol/PrivateTypes.h
@@ -287,10 +287,16 @@ namespace protocol
 	bool SerializePersistentData(const PersistentData & pd, utils::DataWriter & writer);
 	
 	/**
-	 Deserializes apersistent data from the |reader| into the |pd| reference.
+	 Deserializes a persistent data from the |reader| into the |pd| reference.
 	 Returns false if the byte stream contains invalid data.
 	 */
 	bool DeserializePersistentData(PersistentData & pd, utils::DataReader & reader);
+	
+	/**
+	 Deserializes a persistent data in old format from the |reader| into the |pd| reference.
+	 Returns false if the byte stream contains invalid old data format.
+	 */
+	bool TryDeserializeOldPersistentData(PersistentData & pd, utils::DataReader & reader); // DATA_MIGRATION_TAG
 		
 } // io::getlime::powerAuth::detail
 } // io::getlime::powerAuth


### PR DESCRIPTION
This change adds a support for old data format to the very low level PA code. We have still bank with clients running on very old, closed source version of the library, and thus I've decided to add that support to the core of the mobile SDK.