### PR TITLE
watchOS SDK bugfixes & Improvements

### DIFF
--- a/proj-xcode/Classes/sdk/PowerAuthToken.h
+++ b/proj-xcode/Classes/sdk/PowerAuthToken.h
@@ -110,6 +110,21 @@ typedef id PowerAuthTokenStoreTask;
 													 completion:(nonnull void(^)(PowerAuthToken * _Nullable token, NSError * _Nullable error))completion;
 
 /**
+ Create a new access token with given name without needing an authentication object. The method
+ is useful only on watchOS platform, when the token is being acquired from counterpart iOS application.
+ In this case, it's expected that token is already cached on iPhone and therefore the authentication
+ object is not required.
+ 
+ On iOS, method always returns invalid parameter error.
+ 
+ Returns cancellable object if operation is asynchronous, or nil, when the completion
+ block was executed synchronously. That typically happens when token is locally present
+ and available (e.g. doesn't need to be acquired from the server) or in case of error.
+ */
+- (nullable PowerAuthTokenStoreTask) requestAccessTokenWithName:(nonnull NSString*)name
+													 completion:(nonnull void(^)(PowerAuthToken * _Nullable token, NSError * _Nullable error))completion;
+
+/**
  Removes previously created access token from the server and from local database.
  
  Note that if the removal request doesn't succeed, then the local token's data is not removed.

--- a/proj-xcode/Classes/token/PA2PrivateHttpTokenProvider.m
+++ b/proj-xcode/Classes/token/PA2PrivateHttpTokenProvider.m
@@ -44,6 +44,11 @@
 	return self;
 }
 
+- (BOOL) authenticationIsRequired
+{
+	return YES;
+}
+
 - (void) prepareInstanceForConfiguration:(PowerAuthConfiguration*)configuration
 {
 	// Prepare encryptor

--- a/proj-xcode/Classes/token/PA2PrivateRemoteTokenProvider.h
+++ b/proj-xcode/Classes/token/PA2PrivateRemoteTokenProvider.h
@@ -27,6 +27,11 @@
 @protocol PA2PrivateRemoteTokenProvider <NSObject>
 
 /**
+ Implementation may return YES, if `PowerAuthAuthentication` object is required for getting remote token.
+ */
+- (BOOL) authenticationIsRequired;
+
+/**
  Called once per instance, before request or remove methods are called. So, the implementation can safely put
  a lazy initialization code to this method.
  */
@@ -40,7 +45,7 @@
  block was executed synchronously. That typically happens in case of error.
  */
 - (nullable PowerAuthTokenStoreTask) requestTokenWithName:(nonnull NSString*)name
-										   authentication:(nonnull PowerAuthAuthentication*)authentication
+										   authentication:(nullable PowerAuthAuthentication*)authentication
 											   completion:(nonnull void(^)(PA2PrivateTokenData * _Nullable tokenData, NSError * _Nullable error))completion;
 
 /**

--- a/proj-xcode/Classes/token/PA2PrivateTokenKeychainStore.m
+++ b/proj-xcode/Classes/token/PA2PrivateTokenKeychainStore.m
@@ -129,12 +129,33 @@ static void _synchronizedVoid(PA2PrivateTokenKeychainStore  * obj, void(^block)(
 	return [_statusProvider hasValidActivation];
 }
 
-
 - (PowerAuthTokenStoreTask) requestAccessTokenWithName:(NSString*)name
 										authentication:(PowerAuthAuthentication*)authentication
 											completion:(void(^)(PowerAuthToken * token, NSError * error))completion
 {
-	if (!name || !authentication || !completion) {
+	return [self requestAccessTokenImpl:name authentication:authentication completion:completion];
+}
+
+- (PowerAuthTokenStoreTask) requestAccessTokenWithName:(NSString*)name
+											completion:(void(^)(PowerAuthToken * token, NSError * error))completion
+{
+	return [self requestAccessTokenImpl:name authentication:nil completion:completion];
+}
+
+/*
+ This is an actual implementation of `requestAccessTokenWithName...` method, but allowing authentication to be nil.
+ */
+- (PowerAuthTokenStoreTask) requestAccessTokenImpl:(NSString*)name
+									authentication:(PowerAuthAuthentication*)authentication
+										completion:(void(^)(PowerAuthToken * token, NSError * error))completion
+{
+	if (!name || !completion) {
+		if (completion) {
+			completion(nil, [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeWrongParameter userInfo:nil]);
+		}
+		return nil;
+	}
+	if (!authentication && [_remoteTokenProvider authenticationIsRequired]) {
 		if (completion) {
 			completion(nil, [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeWrongParameter userInfo:nil]);
 		}

--- a/proj-xcode/Classes/watch/PA2WCSessionManager.m
+++ b/proj-xcode/Classes/watch/PA2WCSessionManager.m
@@ -335,8 +335,9 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
 	if (!session) {
 		// On IOS, switch to debug build and check log what's the reason of unavailability.
 		// On watchOS, the session is typically not activated
+		PALog(@"PA2WCSessionManager: WCSession is currently not available for messaging.");
 		if (completion) {
-			completion(nil, PA2MakeError(PA2ErrorCodeWatchConnectivity, @"PA2WCSessionManager: WCSession is not available at this time."));
+			completion(nil, PA2MakeError(PA2ErrorCodeWatchConnectivity, @"PA2WCSessionManager: WCSession is currently not available for messaging."));
 		}
 		return;
 	}

--- a/proj-xcode/Classes/watch/model/PA2WCSessionPacket_Success.m
+++ b/proj-xcode/Classes/watch/model/PA2WCSessionPacket_Success.m
@@ -31,7 +31,7 @@
 - (id) initWithDictionary:(NSDictionary*)dictionary
 {
 	NSNumber * num = PA2ObjectAs(dictionary[PA2WCSessionPacket_KEY_SUCCESS], NSNumber);
-	if (!num) {
+	if (num == nil) {
 		return nil;
 	}
 	self = [super init];

--- a/proj-xcode/Extensions/WatchOS/private/PA2WatchSynchronizationService.m
+++ b/proj-xcode/Extensions/WatchOS/private/PA2WatchSynchronizationService.m
@@ -71,28 +71,49 @@
 - (void) updateActivationId:(nullable NSString*)activationId forSessionInstanceId:(nonnull NSString*)sessionInstanceId
 {
 	if (sessionInstanceId.length > 0) {
+		BOOL removeAssociatedTokens = NO;
 		NSData * currentData = [_statusKeychain dataForKey:sessionInstanceId status:NULL];
 		if (activationId) {
 			NSData * activationIdData = [activationId dataUsingEncoding:NSUTF8StringEncoding];
 			if (currentData) {
 				if (![currentData isEqualToData:activationIdData]) {
 					[_statusKeychain updateValue:activationIdData forKey:sessionInstanceId];
-					PALog(@"PA2WatchSynchronizationService: Session with instanceId %@' is now activated (with different activation ID).", sessionInstanceId);
+					PALog(@"PA2WatchSynchronizationService: Session with instanceId '%@' is now activated (with different activation ID).", sessionInstanceId);
+					removeAssociatedTokens = YES;
 				}
 			} else {
 				[_statusKeychain addValue:activationIdData forKey:sessionInstanceId];
-				PALog(@"PA2WatchSynchronizationService: Session with instanceId %@' is now activated.", sessionInstanceId);
+				PALog(@"PA2WatchSynchronizationService: Session with instanceId '%@' is now activated.", sessionInstanceId);
 			}
 		} else {
 			// Removing activation status
 			if (currentData) {
 				[_statusKeychain deleteDataForKey:sessionInstanceId];
-				PALog(@"PA2WatchSynchronizationService: Session with instanceId %@' is no longer activated.", sessionInstanceId);
+				PALog(@"PA2WatchSynchronizationService: Session with instanceId '%@' is no longer activated.", sessionInstanceId);
 			}
+			removeAssociatedTokens = YES;
+		}
+		// If activation has been removed, or activationId has been changed, then we should remove all associated tokens
+		if (removeAssociatedTokens) {
+			[self removeAllTokensForInstanceId:sessionInstanceId];
 		}
 	} else {
 		PALog(@"PA2WatchSynchronizationService: ERROR: Session's instanceId is empty.");
 	}
+}
+
+#pragma mark - Private methods
+
+- (void) removeAllTokensForInstanceId:(NSString*)instanceId
+{
+	PALog(@"PA2WatchSynchronizationService: Removing all tokens for instanceId '%@'", instanceId);
+	PA2Keychain * keychain = [[PA2Keychain alloc] initWithIdentifier:instanceId];
+	NSString * keychainPrefix = [PA2PrivateTokenKeychainStore keychainPrefixForInstanceId:instanceId];
+	[[keychain allItems] enumerateKeysAndObjectsUsingBlock:^(NSString * identifier, id foo, BOOL * stop) {
+		if ([identifier hasPrefix:keychainPrefix]) {
+			[keychain deleteDataForKey:identifier];
+		}
+	}];
 }
 
 


### PR DESCRIPTION
This pull request addresses several bugs which I recently found in watchOS and its counterpart IOS SDK:

- Fixed packet handling when watchOS requests IOS for token and the token doesn't exist.
- Improved error reporting when watchOS requests for token and IOS counterpart has no longer a valid activation.
- PowerAuthTokenStore on watchOS now can requst for tokens without using PowerAuthAuthentication
- If activation is removed from watchOS, then the associated tokens are also removed from keychain on watchOS
- Various small improvements, like more safe cancellable object impl., better logging, etc...