### PR TITLE
Android: Fix #75: Always try to parse response as JSON.

### DIFF
--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/exceptions/ErrorResponseApiException.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/exceptions/ErrorResponseApiException.java
@@ -16,6 +16,8 @@
 
 package io.getlime.security.powerauth.networking.exceptions;
 
+import com.google.gson.JsonObject;
+
 import io.getlime.core.rest.model.base.entity.Error;
 
 /**
@@ -27,21 +29,49 @@ public class ErrorResponseApiException extends Exception {
     /**
      * Error response received from the server
      */
-    private Error mErrorResponse;
+    private Error errorResponse;
+
+    /**
+     * Full response body received from the server
+     */
+    private String responseBody;
+
+    /**
+     * JSON parsed from response body or null if received content is not JSON
+     */
+    private JsonObject responseJson;
+
 
     /**
      * Constructs a new exception with error received from server.
      *
      * @param errorResponse error received from server
      */
-    public ErrorResponseApiException(Error errorResponse) {
-        this.mErrorResponse = errorResponse;
+    public ErrorResponseApiException(Error errorResponse, String responseBody, JsonObject responseJson) {
+        this.errorResponse = errorResponse;
+        this.responseBody = responseBody;
+        this.responseJson = responseJson;
     }
 
     /**
      * @return ErrorModel with failure reason
      */
     public Error getErrorResponse() {
-        return mErrorResponse;
+        return errorResponse;
+    }
+
+    /**
+     * @return Full response body received from the server
+     */
+    public String getResponseBody() {
+        return responseBody;
+    }
+
+
+    /**
+     * @return JsonObject parsed from response body or null if received content is not JSON
+     */
+    public JsonObject getResponseJson() {
+        return responseJson;
     }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/exceptions/FailedApiException.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/exceptions/FailedApiException.java
@@ -16,6 +16,8 @@
 
 package io.getlime.security.powerauth.networking.exceptions;
 
+import com.google.gson.JsonObject;
+
 /**
  * Signals that a REST connection failed with an unknown response from the server.
  * You can investigate a received HTTP response code and response body string
@@ -33,14 +35,21 @@ public class FailedApiException extends Exception {
     private String responseBody;
 
     /**
+     * JSON parsed from response body or null if received content is not JSON
+     */
+    private JsonObject responseJson;
+
+    /**
      * Constructs an exception with response code and response body.
      *
      * @param responseCode HTTP response code
      * @param responseBody HTTP response body
+     * @param responseJson JsonObject parsed from responseBody
      */
-    public FailedApiException(int responseCode, String responseBody) {
+    public FailedApiException(int responseCode, String responseBody, JsonObject responseJson) {
         this.responseCode = responseCode;
         this.responseBody = responseBody;
+        this.responseJson = responseJson;
     }
 
 
@@ -50,20 +59,33 @@ public class FailedApiException extends Exception {
      * @param message message from another exception
      * @param responseCode HTTP response code
      * @param responseBody HTTP response body
+     * @param responseJson JsonObject parsed from responseBody
      */
-    public FailedApiException(String message, int responseCode, String responseBody) {
+    public FailedApiException(String message, int responseCode, String responseBody, JsonObject responseJson) {
         super(message);
         this.responseCode = responseCode;
         this.responseBody = responseBody;
+        this.responseJson = responseJson;
     }
 
     /**
      * @return HTTP response code
      */
-    public int getResponseCode() { return responseCode; }
+    public int getResponseCode() {
+        return responseCode;
+    }
 
     /**
      * @return HTTP response body. The returned value may be null.
      */
-    public String getResponseBody() { return responseBody; }
+    public String getResponseBody() {
+        return responseBody;
+    }
+
+    /**
+     * @return JsonObject parsed from response body or null if received content is not JSON
+     */
+    public JsonObject getResponseJson() {
+        return responseJson;
+    }
 }


### PR DESCRIPTION
This change always adds response body and parsed `JsonObject` (if possible) to exceptions generated in our networking code.

Affected exceptions: `ErrorResponseApiException`, `FailedApiException`