### PR TITLE
iOS & Android: Fix #108: for post-activation device's public key fingerprint calculation

### DIFF
--- a/include/PowerAuth/PublicTypes.h
+++ b/include/PowerAuth/PublicTypes.h
@@ -462,8 +462,11 @@ namespace powerAuth
 		 You can display this code to the UI and user can confirm visually
 		 if the code is the same on both, server & client sides. This feature
 		 must be supported on the server's side of the activation flow.
+		 
+		 Note: The value is equivalent to H_K_DEVICE_PUBLIC mentioned in
+		 PowerAuth crypto protocol documentation.
 		 */
-		std::string	hkDevicePublicKey;
+		std::string	activationFingerprint;
 	};
 	
 	

--- a/include/PowerAuth/Session.h
+++ b/include/PowerAuth/Session.h
@@ -143,6 +143,15 @@ namespace powerAuth
 		std::string activationIdentifier() const;
 		
 		/**
+		 If the session has valid activation, then returns decimalized fingerprint, calculated
+		 from device's public key. Otherwise returns empty string.
+		 
+		 Note: The value is equivalent to H_K_DEVICE_PUBLIC mentioned in PowerAuth crypto
+		 protocol documentation.
+		 */
+		std::string activationFingerprint() const;
+		
+		/**
 		 Starts a new activation process. The session must have valid setup. Once the activation
 		 is started you have to complete whole activation sequence or reset a whole session.
 		 

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/ActivationStep2Result.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/ActivationStep2Result.java
@@ -33,10 +33,10 @@ public class ActivationStep2Result {
      if the code is the same on both, server &amp; client sides. This feature
      must be supported on the server's side of the activation flow.
      */
-    public final String hkDevicePublicKey;
+    public final String activationFingerprint;
 
     public ActivationStep2Result() {
         this.errorCode = 0;
-        this.hkDevicePublicKey = null;
+        this.activationFingerprint = null;
     }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/Session.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/Session.java
@@ -144,6 +144,12 @@ public class Session {
      no activation then returns null.
      */
 	public native String getActivationIdentifier();
+
+	/**
+	 If the session has valid activation, then returns decimalized fingerprint, calculated
+	 from device's public key. Otherwise returns null.
+	 */
+	public native String getActivationFingerprint();
     
     /**
      Starts a new activation process. The Session must be in its initial state. Once the

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -345,6 +345,14 @@ public class PowerAuthSDK {
     }
 
     /**
+     * Get activation fingerpint calculated from device's public key.
+     * @return Activation fingerprint or null if object has no activation.
+     */
+    public @Nullable String getActivationFingerprint() {
+        return mSession.getActivationFingerprint();
+    }
+
+    /**
      * Return the encryptor factory instance, useful for generating custom encryptors.
      *
      * @return Encryptor factory instance.
@@ -523,7 +531,7 @@ public class PowerAuthSDK {
                 final ActivationStep2Result resultStep2 = mSession.validateActivationResponse(paramStep2);
                 if (resultStep2.errorCode == ErrorCode.OK) {
                     // Everything was OK
-                    listener.onActivationCreateSucceed(resultStep2.hkDevicePublicKey, response.getCustomAttributes());
+                    listener.onActivationCreateSucceed(resultStep2.activationFingerprint, response.getCustomAttributes());
                 } else {
                     // Error occurred
                     mSession.resetSession();
@@ -632,7 +640,7 @@ public class PowerAuthSDK {
                     ActivationStep2Result step2Result = mSession.validateActivationResponse(step2Param);
 
                     if (step2Result != null && step2Result.errorCode == ErrorCode.OK) {
-                        listener.onActivationCreateSucceed(step2Result.hkDevicePublicKey, activationCreateResponse.getCustomAttributes());
+                        listener.onActivationCreateSucceed(step2Result.activationFingerprint, activationCreateResponse.getCustomAttributes());
                     } else {
                         mSession.resetSession();
                         listener.onActivationCreateFailed(new PowerAuthErrorException(PowerAuthErrorCodes.PA2ErrorCodeInvalidActivationData));

--- a/proj-xcode/Classes/core/PA2Session.h
+++ b/proj-xcode/Classes/core/PA2Session.h
@@ -110,6 +110,12 @@
 @property (nonatomic, strong, readonly, nullable) NSString * activationIdentifier;
 
 /**
+ If the session has valid activation, then returns decimalized fingerprint, calculated
+ from device's public key. Otherwise returns nil.
+ */
+@property (nonatomic, strong, readonly, nullable) NSString * activationFingerprint;
+
+/**
  Starts a new activation process. The session must have valid setup. Once the activation 
  is started you have to complete whole activation sequence or reset a whole session.
  

--- a/proj-xcode/Classes/core/PA2Session.mm
+++ b/proj-xcode/Classes/core/PA2Session.mm
@@ -128,12 +128,13 @@ using namespace io::getlime::powerAuth;
 
 - (nullable NSString*) activationIdentifier
 {
-	if (_session->hasValidActivation()) {
-		return cc7::objc::CopyToNSString(_session->activationIdentifier());
-	}
-	return nil;
+	return cc7::objc::CopyToNullableNSString(_session->activationIdentifier());
 }
 
+- (nullable NSString*) activationFingerprint
+{
+	return cc7::objc::CopyToNullableNSString(_session->activationFingerprint());
+}
 
 - (nullable PA2ActivationStep1Result*) startActivation:(nonnull PA2ActivationStep1Param*)param
 {

--- a/proj-xcode/Classes/core/PA2Types.mm
+++ b/proj-xcode/Classes/core/PA2Types.mm
@@ -319,7 +319,7 @@ void PA2ActivationStep2ParamToStruct(PA2ActivationStep2Param * p2, io::getlime::
 PA2ActivationStep2Result * PA2ActivationStep2ResultToObject(const io::getlime::powerAuth::ActivationStep2Result& cpp_r2)
 {
 	PA2ActivationStep2Result * res = [[PA2ActivationStep2Result alloc] init];
-	res.hkDevicePublicKey			= cc7::objc::CopyToNSString(cpp_r2.hkDevicePublicKey);
+	res.hkDevicePublicKey			= cc7::objc::CopyToNSString(cpp_r2.activationFingerprint);
 	return res;
 }
 

--- a/proj-xcode/Classes/sdk/PowerAuthSDK.h
+++ b/proj-xcode/Classes/sdk/PowerAuthSDK.h
@@ -212,6 +212,11 @@
  */
 @property (nonatomic, strong, nullable, readonly) NSString *activationIdentifier;
 
+/**
+ Read only property contains fingerprint calculated from device's public key or nil if object has no valid activation.
+ */
+@property (nonatomic, strong, nullable, readonly) NSString *activationFingerprint;
+
 
 /** Fetch the activation status for current activation.
  

--- a/proj-xcode/Classes/sdk/PowerAuthSDK.m
+++ b/proj-xcode/Classes/sdk/PowerAuthSDK.m
@@ -761,6 +761,11 @@ static PowerAuthSDK * s_inst;
 	return _session.activationIdentifier;
 }
 
+- (NSString*) activationFingerprint
+{
+	return _session.activationFingerprint;
+}
+
 #pragma mark Getting activations state
 
 - (PA2OperationTask*) fetchActivationStatusWithCallback:(void(^)(PA2ActivationStatus *status, NSDictionary *customObject, NSError *error))callback {

--- a/src/PowerAuth/jni/SessionJNI.cpp
+++ b/src/PowerAuth/jni/SessionJNI.cpp
@@ -226,6 +226,18 @@ CC7_JNI_METHOD(jstring, getActivationIdentifier)
 }
 
 //
+// public native String getActivationFingerprint()
+//
+CC7_JNI_METHOD(jstring, getActivationFingerprint)
+{
+	auto session = CC7_THIS_OBJ();
+	if (!session || !session->hasValidActivation()) {
+		return NULL;
+	}
+	return cc7::jni::CopyToNullableJavaString(env, session->activationFingerprint());
+}
+
+//
 // public native ActivationStep1Result startActivation(ActivationStep1Param param);
 //
 CC7_JNI_METHOD_PARAMS(jobject, startActivation, jobject param)
@@ -283,7 +295,7 @@ CC7_JNI_METHOD_PARAMS(jobject, validateActivationResponse, jobject param)
 	jobject resultObject = cc7::jni::CreateJavaObject(env, CC7_JNI_MODULE_CLASS_PATH("ActivationStep2Result"), "()V");
 	CC7_JNI_SET_FIELD_INT(resultObject, resultClazz, "errorCode", code);
 	if (code == EC_Ok) {
-		CC7_JNI_SET_FIELD_STRING(resultObject, resultClazz, "hkDevicePublicKey",  cc7::jni::CopyToJavaString(env, cppResult.hkDevicePublicKey));
+		CC7_JNI_SET_FIELD_STRING(resultObject, resultClazz, "activationFingerprint",  cc7::jni::CopyToJavaString(env, cppResult.activationFingerprint));
 	}
 	return resultObject;
 }

--- a/src/PowerAuth/protocol/Constants.h
+++ b/src/PowerAuth/protocol/Constants.h
@@ -83,7 +83,7 @@ namespace protocol
 	const size_t ACTIVATION_SHORT_ID_SIZE = 11;
 	
 	// Length of decimalized signature, calculated from device public key
-	const size_t HK_DEVICE_PUBLIC_KEY_SIZE = 8;
+	const size_t ACTIVATION_FINGERPRINT_SIZE = 8;
 	
 	// Length of status blob
 	const size_t STATUS_BLOB_SIZE = 32;

--- a/src/PowerAuth/protocol/ProtocolUtils.cpp
+++ b/src/PowerAuth/protocol/ProtocolUtils.cpp
@@ -544,10 +544,10 @@ namespace protocol
 	{
 		std::string result = std::to_string(val);
 		static const std::string zero("00000000");
-		if (result.length() < protocol::HK_DEVICE_PUBLIC_KEY_SIZE) {
-			result.insert(0, zero.substr(0, protocol::HK_DEVICE_PUBLIC_KEY_SIZE - result.length()));
+		if (result.length() < protocol::ACTIVATION_FINGERPRINT_SIZE) {
+			result.insert(0, zero.substr(0, protocol::ACTIVATION_FINGERPRINT_SIZE - result.length()));
 		}
-		CC7_ASSERT(result.length() == protocol::HK_DEVICE_PUBLIC_KEY_SIZE, "Wrong normalized size");
+		CC7_ASSERT(result.length() == protocol::ACTIVATION_FINGERPRINT_SIZE, "Wrong normalized size");
 		return result;
 	}
 	

--- a/src/PowerAuthTests/pa2SessionTests.cpp
+++ b/src/PowerAuthTests/pa2SessionTests.cpp
@@ -320,7 +320,7 @@ namespace powerAuthTests
 				// SERVER STEP 2
 				//  ... validate result1 & prepare param2
 				ActivationStep2Param param2;
-				std::string hkKEY_DEVICE_PUBLIC;
+				std::string ACTIVATION_FINGERPRINT;
 				cc7::ByteArray MASTER_SHARED_SECRET;
 				{
 					// Validate "received" activation signature
@@ -393,7 +393,7 @@ namespace powerAuthTests
 					v = v % 100000000;
 					char buffer[32];
 					sprintf(buffer, "%08d", v);
-					hkKEY_DEVICE_PUBLIC = buffer;
+					ACTIVATION_FINGERPRINT = buffer;
 					
 					ccstMessage("Shared secret: %s", MASTER_SHARED_SECRET.hexString().c_str());
 				}
@@ -403,7 +403,7 @@ namespace powerAuthTests
 				{
 					ec = s1.validateActivationResponse(param2, result2);
 					ccstAssertEqual(ec, EC_Ok);
-					ccstAssertEqual(hkKEY_DEVICE_PUBLIC, result2.hkDevicePublicKey);
+					ccstAssertEqual(ACTIVATION_FINGERPRINT, result2.activationFingerprint);
 					
 					ccstAssertTrue(s1.hasValidSetup());
 					ccstAssertFalse(s1.canStartActivation());
@@ -509,6 +509,8 @@ namespace powerAuthTests
 					ccstAssertFalse(s1.canStartActivation());
 					ccstAssertFalse(s1.hasPendingActivation());
 					ccstAssertTrue(s1.hasValidActivation());
+					// Compare whether the fingerprint is still correct
+					ccstAssertEqual(s1.activationFingerprint(), ACTIVATION_FINGERPRINT);
 				}
 				// Signature test #1
 				{


### PR DESCRIPTION
This change is adding support for device's public key fingerprint calculation available after the activation is completed.

I have also renamed property `hkDevicePublicKey` in `ActivationStep2Result` internal structure,  to `activationFingerprint`.  The naming is now persistent across the rest of the SDK