### PR TITLE
Issues/106 configurable ios log

### DIFF
--- a/proj-xcode/Classes/core/PA2CoreLog.h
+++ b/proj-xcode/Classes/core/PA2CoreLog.h
@@ -23,34 +23,28 @@
 #endif
 
 #ifdef ENABLE_PA2_CORE_LOG
-
-	// Implementations
-
-	PA2_EXTERN_C void PA2CoreLogImpl(NSString * format, ...);
-	PA2_EXTERN_C void PA2CoreLogSetEnabledImpl(BOOL enabled);
-	PA2_EXTERN_C BOOL PA2CoreLogIsEnabledImpl(void);
-
-	// Macros
-
 	/**
 	 PA2CoreLog(...) macro prints a debug information into the debug console and is used internally
 	 in the PowerAuthCore library. For DEBUG builds, the macro is expanded to internal function which uses NSLog().
 	 For RELEASE builds, the message is completely suppressed during the compilation.
 	 */
-	#define PA2CoreLog(...) 				PA2CoreLogImpl(__VA_ARGS__)
-	/**
-	 PA2CoreLogSetEnabled(BOOL enabled) disables or enables PA2Log() messages.
-	 */
-	#define PA2CoreLogSetEnabled(enabled)	PA2CoreLogSetEnabledImpl(enabled)
-	/**
-	 BOOL PA2CoreLogIsEnabled() returns current status of PA2Log() macro logging.
-	 */
-	#define PA2CoreLogIsEnabled()			PA2CoreLogIsEnabledImpl()
+	PA2_EXTERN_C void PA2CoreLogImpl(NSString * format, ...);
+	#define PA2CoreLog(...) PA2CoreLogImpl(__VA_ARGS__)
 
 #else
 	// If PA2Log is disabled, then disable everything
 	#define PA2CoreLog(...)
-	#define PA2CoreLogSetEnabled(enabled)
-	#define PA2CoreLogIsEnabled() 			NO
 
 #endif // ENABLE_PA2_CORE_LOG
+
+/**
+ Function enables or disables internal PowerAuthCore logging.
+ Note that it's effective only when library is compiled in DEBUG build configuration.
+ */
+PA2_EXTERN_C void PA2CoreLogSetEnabled(BOOL enabled);
+
+/**
+ Function returns YES if internal PowerAuthCore logging is enabled.
+ Note that when library is compiled in RELEASE configuration, then always returns NO.
+ */
+PA2_EXTERN_C BOOL PA2CoreLogIsEnabled(void);

--- a/proj-xcode/Classes/core/PA2CoreLog.h
+++ b/proj-xcode/Classes/core/PA2CoreLog.h
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "PA2Macros.h"
+
+#pragma mark - Core logging
+
+#if defined(DEBUG) && !defined(ENABLE_PA2_CORE_LOG)
+#define ENABLE_PA2_CORE_LOG
+#endif
+
+#ifdef ENABLE_PA2_CORE_LOG
+
+	// Implementations
+
+	PA2_EXTERN_C void PA2CoreLogImpl(NSString * format, ...);
+	PA2_EXTERN_C void PA2CoreLogSetEnabledImpl(BOOL enabled);
+	PA2_EXTERN_C BOOL PA2CoreLogIsEnabledImpl(void);
+
+	// Macros
+
+	/**
+	 PA2CoreLog(...) macro prints a debug information into the debug console and is used internally
+	 in the PowerAuthCore library. For DEBUG builds, the macro is expanded to internal function which uses NSLog().
+	 For RELEASE builds, the message is completely suppressed during the compilation.
+	 */
+	#define PA2CoreLog(...) 				PA2CoreLogImpl(__VA_ARGS__)
+	/**
+	 PA2CoreLogSetEnabled(BOOL enabled) disables or enables PA2Log() messages.
+	 */
+	#define PA2CoreLogSetEnabled(enabled)	PA2CoreLogSetEnabledImpl(enabled)
+	/**
+	 BOOL PA2CoreLogIsEnabled() returns current status of PA2Log() macro logging.
+	 */
+	#define PA2CoreLogIsEnabled()			PA2CoreLogIsEnabledImpl()
+
+#else
+	// If PA2Log is disabled, then disable everything
+	#define PA2CoreLog(...)
+	#define PA2CoreLogSetEnabled(enabled)
+	#define PA2CoreLogIsEnabled() 			NO
+
+#endif // ENABLE_PA2_CORE_LOG

--- a/proj-xcode/Classes/core/PA2CoreLog.m
+++ b/proj-xcode/Classes/core/PA2CoreLog.m
@@ -14,26 +14,32 @@
  * limitations under the License.
  */
 
-#import <UIKit/UIKit.h>
+#import "PA2CoreLog.h"
+#import <cc7/Platform.h>
 
-//! Project version number for PowerAuth2.
-FOUNDATION_EXPORT double PowerAuth2VersionNumber;
+#ifdef ENABLE_PA2_CORE_LOG
 
-//! Project version string for PowerAuth2.
-FOUNDATION_EXPORT const unsigned char PowerAuth2VersionString[];
+void PA2CoreLogImpl(NSString * format, ...)
+{
+	if (!PA2CoreLogIsEnabled()) {
+		return;
+	}
+	va_list args;
+	va_start(args, format);
+	NSString * message = [[NSString alloc] initWithFormat:format arguments:args];
+	va_end(args);
+	
+	NSLog(@"[PowerAuthCore] %@", message);
+}
 
-#import "PowerAuthSDK.h"
+void PA2CoreLogSetEnabledImpl(BOOL enabled)
+{
+	CC7_LOG_ENABLE(enabled);
+}
 
-#import "PA2Client.h"
-#import "PA2Log.h"
-#import "PA2Macros.h"
-#import "PA2System.h"
-#import "PA2Keychain.h"
+BOOL PA2CoreLogIsEnabledImpl(void)
+{
+	return CC7_LOG_IS_ENABLED();
+}
 
-#import "PA2ErrorConstants.h"
-#import "PA2PasswordUtil.h"
-#import "PA2Password.h"
-#import "PA2OtpUtil.h"
-#import "PA2ECIESEncryptor.h"
-
-#import "PA2WCSessionManager.h"
+#endif // ENABLE_PA2_CORE_LOG

--- a/proj-xcode/Classes/core/PA2CoreLog.m
+++ b/proj-xcode/Classes/core/PA2CoreLog.m
@@ -32,14 +32,14 @@ void PA2CoreLogImpl(NSString * format, ...)
 	NSLog(@"[PowerAuthCore] %@", message);
 }
 
-void PA2CoreLogSetEnabledImpl(BOOL enabled)
+#endif // ENABLE_PA2_CORE_LOG
+
+void PA2CoreLogSetEnabled(BOOL enabled)
 {
 	CC7_LOG_ENABLE(enabled);
 }
 
-BOOL PA2CoreLogIsEnabledImpl(void)
+BOOL PA2CoreLogIsEnabled(void)
 {
 	return CC7_LOG_IS_ENABLED();
 }
-
-#endif // ENABLE_PA2_CORE_LOG

--- a/proj-xcode/Classes/core/PA2Macros.h
+++ b/proj-xcode/Classes/core/PA2Macros.h
@@ -16,32 +16,6 @@
 
 #import <Foundation/Foundation.h>
 
-#pragma mark - Custom logging
-
-/**
- PALog(...) macro prints debug information into the debug console and is used internally
- in the PowerAuth SDK. By default, the macro is expanded to NSLog(...), but only for DEBUG 
- build configuration. You can control this behavior by defining following macros:
- 
-	ENABLE_PA2_LOG		- force enables debug logs
-	DISABLE_PA2_LOG		- force disables debug logs
- 
- If both, DISABLE_PA2_LOG and ENABLE_PA2_LOG are defined, then the compile error is produced.
- */
-#if defined(DEBUG) && !defined(DISABLE_PA2_LOG) && !defined(ENABLE_PA2_LOG)
-#define ENABLE_PA2_LOG
-#endif
-
-#if defined(DISABLE_PA2_LOG) && defined(ENABLE_PA2_LOG)
-#error PowerAuth debug log is force disabled and enabled at the same time
-#endif
-
-#ifdef ENABLE_PA2_LOG
-	#define PALog(...) NSLog(__VA_ARGS__)
-#else
-	#define PALog(...)
-#endif
-
 /**
  Macro for marking interface as deprecated.
  
@@ -63,4 +37,6 @@
 	#define PA2_EXTERN_C_BEGIN
 	#define PA2_EXTERN_C_END
 #endif
+
+
 

--- a/proj-xcode/Classes/core/PA2PrivateCrypto_Ext.m
+++ b/proj-xcode/Classes/core/PA2PrivateCrypto_Ext.m
@@ -15,6 +15,7 @@
  */
 
 #import "PA2PrivateCrypto.h"
+#import "PA2Log.h"
 
 #if !defined(PA2_EXTENSION_SDK)
 #error "This file is for IOS extensions or WatchOS projects only"
@@ -49,6 +50,6 @@ NSData * PA2PrivateCrypto_GetRandomBytes(size_t count)
 			return data;
 		}
 	}
-	PALog(@"PA2PrivateCrypto_GetRandomBytes: Failed to generat %@ random bytes.", @(count));
+	PA2Log(@"PA2PrivateCrypto_GetRandomBytes: Failed to generat %@ random bytes.", @(count));
 	return nil;
 }

--- a/proj-xcode/Classes/core/PA2PrivateImpl.h
+++ b/proj-xcode/Classes/core/PA2PrivateImpl.h
@@ -26,6 +26,7 @@
 #import "PA2Password.h"
 #import "PA2Encryptor.h"
 #import "PA2ECIESEncryptor.h"
+#import "PA2CoreLog.h"
 
 /*
  This header contains various private interfaces, internally used

--- a/proj-xcode/Classes/core/PA2PrivateImpl.mm
+++ b/proj-xcode/Classes/core/PA2PrivateImpl.mm
@@ -16,7 +16,6 @@
 
 #import "PA2PrivateImpl.h"
 #import "PA2Session.h"
-#import "PA2Macros.h"
 
 using namespace io::getlime::powerAuth;
 
@@ -39,9 +38,9 @@ void PA2Objc_DebugDumpErrorImpl(id instance, NSString * message, ErrorCode code)
 		if ([instance isKindOfClass:[PA2Session class]]) {
 			PA2Session * session = (PA2Session*)instance;
 			unsigned int sessionId = (unsigned int)session.sessionIdentifier;
-			PALog(@"%@(0x%p, ID:%d): %@: Low level operation failed with error %@.", className, instancePtr, sessionId, message, codeStr);
+			PA2CoreLog(@"%@(0x%p, ID:%d): %@: Low level operation failed with error %@.", className, instancePtr, sessionId, message, codeStr);
 		} else {
-			PALog(@"%@(0x%p): %@: Low level operation failed with error %@.", className, instancePtr, message, codeStr);
+			PA2CoreLog(@"%@(0x%p): %@: Low level operation failed with error %@.", className, instancePtr, message, codeStr);
 		}
 	}
 }

--- a/proj-xcode/Classes/core/PA2Session.mm
+++ b/proj-xcode/Classes/core/PA2Session.mm
@@ -65,7 +65,11 @@ using namespace io::getlime::powerAuth;
 
 + (BOOL) hasDebugFeatures
 {
-	return io::getlime::powerAuth::HasDebugFeaturesTurnedOn();
+	BOOL debug_features = io::getlime::powerAuth::HasDebugFeaturesTurnedOn();
+#if defined(ENABLE_PA2_CORE_LOG) || defined(DEBUG)
+	debug_features |= YES;
+#endif
+	return debug_features;
 }
 
 

--- a/proj-xcode/Classes/keychain/PA2KeychainConfiguration.h
+++ b/proj-xcode/Classes/keychain/PA2KeychainConfiguration.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "PA2Macros.h"
+#import "PA2Log.h"
 
 /** Constant specifying the default name of the 'key' used to store flag in NSUserDefaults about initialized PowerAuthSDK instances. Used to cleanup the keychain data after the app re-install.
  */

--- a/proj-xcode/Classes/networking/base/PA2PrivateNetworking.h
+++ b/proj-xcode/Classes/networking/base/PA2PrivateNetworking.h
@@ -18,6 +18,7 @@
 
 #import "PA2Client.h"
 #import "PA2PrivateMacros.h"
+#import "PA2Log.h"
 
 // Requests / Responses
 #import "PA2CreateActivationRequest.h"

--- a/proj-xcode/Classes/networking/client/PA2Client.m
+++ b/proj-xcode/Classes/networking/client/PA2Client.m
@@ -75,7 +75,7 @@
 						 completion:(void(^)(NSData *data, NSURLResponse *response, NSError *error))completion {
 	
 	if ([url.absoluteString hasPrefix:@"http://"]) {
-		PALog(@"Warning: Using HTTP for communication may create a serious security issue! Use HTTPS in production.");
+		PA2Log(@"Warning: Using HTTP for communication may create a serious security issue! Use HTTPS in production.");
 	}
 	
 	NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
@@ -100,19 +100,19 @@
 	[request setHTTPMethod:@"POST"];
 	[request setHTTPBody:data];
 	
-	PALog(@"PA2Client Request");
-	PALog(@"- Method: POST");
-	PALog(@"- URL: %@", url.absoluteString);
-	PALog(@"- Headers: %@", request.allHTTPHeaderFields);
-	PALog(@"- Body: %@", data ? [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] : @"empty body");
+	PA2Log(@"PA2Client Request");
+	PA2Log(@"- Method: POST");
+	PA2Log(@"- URL: %@", url.absoluteString);
+	PA2Log(@"- Headers: %@", request.allHTTPHeaderFields);
+	PA2Log(@"- Body: %@", data ? [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] : @"empty body");
 	NSURLSessionDataTask *postDataTask = [session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-		PALog(@"PA2Client Response");
-		PALog(@"- URL: %@", url.absoluteString);
-		PALog(@"- Status code: %ld", (long)((NSHTTPURLResponse*)response).statusCode);
-		PALog(@"- Headers: %@", ((NSHTTPURLResponse*)response).allHeaderFields);
-		PALog(@"- Body: %@", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
+		PA2Log(@"PA2Client Response");
+		PA2Log(@"- URL: %@", url.absoluteString);
+		PA2Log(@"- Status code: %ld", (long)((NSHTTPURLResponse*)response).statusCode);
+		PA2Log(@"- Headers: %@", ((NSHTTPURLResponse*)response).allHeaderFields);
+		PA2Log(@"- Body: %@", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
 		if (error) {
-			PALog(@"- Error: %@", error.localizedDescription);
+			PA2Log(@"- Error: %@", error.localizedDescription);
 		}
 		[[NSOperationQueue mainQueue] addOperationWithBlock: ^{
 			completion(data, response, error);

--- a/proj-xcode/Classes/networking/ssl/PA2ClientSslNoValidationStrategy.m
+++ b/proj-xcode/Classes/networking/ssl/PA2ClientSslNoValidationStrategy.m
@@ -15,7 +15,7 @@
  */
 
 #import "PA2ClientSslNoValidationStrategy.h"
-#import "PA2Macros.h"
+#import "PA2Log.h"
 
 @implementation PA2ClientSslNoValidationStrategy
 
@@ -25,7 +25,7 @@
 	
 	// Allow any SSL certificate
 	
-	PALog(@"Warning: SSL validation is disabled. This code must not be present in production!");
+	PA2CriticalWarning(@"SSL validation is disabled. This code must not be present in production!");
 	if([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]){
 		NSURLCredential *credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
 		completionHandler(NSURLSessionAuthChallengeUseCredential,credential);

--- a/proj-xcode/Classes/sdk/PowerAuthSDK+WatchSupport.m
+++ b/proj-xcode/Classes/sdk/PowerAuthSDK+WatchSupport.m
@@ -38,7 +38,7 @@
 	NSString * instanceIdentifier   = self.privateInstanceId;
 	
 	if (!instanceIdentifier) {
-		PALog(@"PowerAuthSDK instance is not properly configured. PowerAuthConfiguration has no instanceId.");
+		PA2Log(@"PowerAuthSDK instance is not properly configured. PowerAuthConfiguration has no instanceId.");
 		return nil;
 	}
 	
@@ -65,7 +65,7 @@
 		[manager sendPacket:packet];
 		return YES;
 	}
-	PALog(@"PowerAuthSDK: Not supported on older iOS versions.");
+	PA2Log(@"PowerAuthSDK: Not supported on older iOS versions.");
 	return NO;
 }
 

--- a/proj-xcode/Classes/sdk/PowerAuthSDK.m
+++ b/proj-xcode/Classes/sdk/PowerAuthSDK.m
@@ -261,7 +261,7 @@ NSString *const PA2ExceptionMissingConfig		= @"PA2ExceptionMissingConfig";
 			// was requested, generate a "fake key" so that signature can silently fail
 			else {
 				if (biometryKey == nil) {
-					PALog(@"ERROR! You are attempting Touch ID authentication despite the fact related key value is not present in the Keychain. We have generated an ad-hoc random key and your authentication will fail. Use PowerAuthSDK:hasBiometryFactor method to check the status of this key and disable Touch ID if the method returns NO / false value.");
+					PA2Log(@"ERROR! You are attempting Touch ID authentication despite the fact related key value is not present in the Keychain. We have generated an ad-hoc random key and your authentication will fail. Use PowerAuthSDK:hasBiometryFactor method to check the status of this key and disable Touch ID if the method returns NO / false value.");
 					biometryKey = [PA2Session generateSignatureUnlockKey];
 				}
 			}
@@ -884,7 +884,7 @@ static PowerAuthSDK * s_inst;
 		error = error || ![_biometryOnlyKeychain deleteDataForKey:_biometryKeyIdentifier];
 	}
 	if (error) {
-		PALog(@"Removing activaton data from keychain failed. We can't recover from this error.");
+		PA2Log(@"Removing activaton data from keychain failed. We can't recover from this error.");
 	}
 	[_tokenStore removeAllLocalTokens];
 	[_session resetSession];

--- a/proj-xcode/Classes/sdk/PowerAuthToken+WatchSupport.m
+++ b/proj-xcode/Classes/sdk/PowerAuthToken+WatchSupport.m
@@ -49,12 +49,12 @@
 				[manager sendPacket:[self prepareTokenDataPacketForWatch]];
 				return YES;
 			}
-			PALog(@"PowerAuthToken: WCSession is not ready for message sending.");
+			PA2Log(@"PowerAuthToken: WCSession is not ready for message sending.");
 		} else {
-			PALog(@"PowerAuthToken: Cannot send token to watch, because token store has no longer a valid activation.");
+			PA2Log(@"PowerAuthToken: Cannot send token to watch, because token store has no longer a valid activation.");
 		}
 	} else {
-		PALog(@"PowerAuthToken: WCSession is not supported on older iOS versions.");
+		PA2Log(@"PowerAuthToken: WCSession is not supported on older iOS versions.");
 	}
 	return NO;
 }
@@ -104,7 +104,7 @@
 			return YES;
 		}
 	}
-	PALog(@"PowerAuthToken: WCSession is not ready for message sending.");
+	PA2Log(@"PowerAuthToken: WCSession is not ready for message sending.");
 	return NO;
 }
 

--- a/proj-xcode/Classes/sdk/PowerAuthToken.m
+++ b/proj-xcode/Classes/sdk/PowerAuthToken.m
@@ -18,7 +18,7 @@
 #import "PA2PrivateTokenData.h"
 #import "PA2PrivateCrypto.h"
 #import "PA2AuthorizationHttpHeader.h"
-#import "PA2Macros.h"
+#import "PA2Log.h"
 
 @implementation PowerAuthToken
 {
@@ -62,9 +62,9 @@
 	if (!self.canGenerateHeader) {
 #if defined(DEBUG)
 		if (!self.isValid) {
-			PALog(@"PowerAuthToken: Token contains invalid data.");
+			PA2Log(@"PowerAuthToken: Token contains invalid data.");
 		} else {
-			PALog(@"PowerAuthToken: The associated token store has no longer valid activation.");
+			PA2Log(@"PowerAuthToken: The associated token store has no longer valid activation.");
 		}
 #endif
 		return nil;
@@ -79,7 +79,7 @@
 	NSData * currentTimeData = [currentTimeString dataUsingEncoding:NSASCIIStringEncoding];
 	NSData * nonce = PA2PrivateCrypto_GetRandomBytes(16);
 	if (nonce.length != 16) {
-		PALog(@"PowerAuthToken: Random generator did not generate enough bytes.");
+		PA2Log(@"PowerAuthToken: Random generator did not generate enough bytes.");
 		return nil;
 	}
 	NSMutableData * data = [nonce mutableCopy];
@@ -91,7 +91,7 @@
 	NSString * nonceBase64 = [nonce base64EncodedStringWithOptions:0];
 	// Final check...
 	if (digest.length == 0 || !digestBase64 || !nonceBase64 || !currentTimeString) {
-		PALog(@"PowerAuthToken: Digest calculation did fail.");
+		PA2Log(@"PowerAuthToken: Digest calculation did fail.");
 		return nil;
 	}
 	NSString * value = [NSString stringWithFormat:

--- a/proj-xcode/Classes/system/PA2Log.h
+++ b/proj-xcode/Classes/system/PA2Log.h
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "PA2CoreLog.h"
+
+#pragma mark - SDK logging
+
+#if defined(DEBUG) && !defined(ENABLE_PA2_LOG)
+#define ENABLE_PA2_LOG
+#endif
+
+#ifdef DISABLE_PA2_LOG
+#warning DISABLE_PA2_LOG is no longer supported. Use PA2LogSetEnabled(NO) in runtime.
+#endif
+
+#ifdef ENABLE_PA2_LOG
+
+	// Implementations
+
+	PA2_EXTERN_C void PA2LogImpl(NSString * format, ...);
+
+	// Macros
+
+	/**
+	 PA2Log(...) macro prints a debug information into the debug console and is used internally
+	 in the PowerAuth SDK. For DEBUG builds, the macro is expanded to internal function which uses NSLog().
+	 For RELEASE builds, the message is completely suppressed during the compilation.
+	 */
+	#define PA2Log(...) 				PA2LogImpl(__VA_ARGS__)
+
+#else
+	// If PA2Log is disabled, then suppress whole log statement
+	#define PA2Log(...)
+
+#endif // ENABLE_PA2_LOG
+
+/**
+ Function enables or disables internal PowerAuth SDK logging.
+ Note that it's effective only when library is compiled in DEBUG build configuration.
+ */
+PA2_EXTERN_C void PA2LogSetEnabled(BOOL enabled);
+
+/**
+ Function returns YES if internal PowerAuth SDK logging is enabled.
+ Note that when library is compiled in RELEASE configuration, then always returns NO.
+ */
+PA2_EXTERN_C BOOL PA2LogIsEnabled(void);
+
+/**
+ PA2CriticalWarning(...) function prints a critical warning information into the debug console and
+ is used internally in the PowerAuth SDK. This kind of warnings are always printed to the DEBUG
+ console and cannot be supressed by configuration.
+ */
+PA2_EXTERN_C void PA2CriticalWarning(NSString * format, ...);

--- a/proj-xcode/Classes/system/PA2Log.m
+++ b/proj-xcode/Classes/system/PA2Log.m
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "PA2Log.h"
+
+#ifdef ENABLE_PA2_LOG
+static BOOL s_log_enabled = NO;
+void PA2LogImpl(NSString * format, ...)
+{
+	if (!s_log_enabled) {
+		return;
+	}
+	va_list args;
+	va_start(args, format);
+	NSString * message = [[NSString alloc] initWithFormat:format arguments:args];
+	va_end(args);
+	
+	NSLog(@"[PowerAuth] %@", message);
+}
+#endif // ENABLE_PA2_LOG
+
+
+void PA2LogSetEnabled(BOOL enabled)
+{
+#ifdef ENABLE_PA2_LOG
+	s_log_enabled = enabled;
+	// Also apply to PA2CoreLog (which internally uses CC7_LOG flag)
+	PA2CoreLogSetEnabled(enabled);
+#endif
+}
+
+BOOL PA2LogIsEnabled(void)
+{
+#ifdef ENABLE_PA2_LOG
+	return s_log_enabled;
+#else
+	return NO;
+#endif
+}
+
+void PA2CriticalWarning(NSString * format, ...)
+{
+	va_list args;
+	va_start(args, format);
+	NSString * message = [[NSString alloc] initWithFormat:format arguments:args];
+	va_end(args);
+	
+	NSLog(@"[PowerAuth] CRITICAL WARNING: %@", message);
+}

--- a/proj-xcode/Classes/token/PA2PrivateTokenKeychainStore.m
+++ b/proj-xcode/Classes/token/PA2PrivateTokenKeychainStore.m
@@ -175,7 +175,7 @@ static void _synchronizedVoid(PA2PrivateTokenKeychainStore  * obj, void(^block)(
 	
 	id<PA2PrivateRemoteTokenProvider> strongTokenProvider = _remoteTokenProvider;
 	if (!strongTokenProvider) {
-		PALog(@"KeychainTokenStore: ERROR: The store has no remote token provider. Returning invalid token error.");
+		PA2Log(@"KeychainTokenStore: ERROR: The store has no remote token provider. Returning invalid token error.");
 		completion(nil, [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeInvalidToken userInfo:nil]);
 		return nil;
 	}
@@ -216,7 +216,7 @@ static void _synchronizedVoid(PA2PrivateTokenKeychainStore  * obj, void(^block)(
 	
 	id<PA2PrivateRemoteTokenProvider> strongTokenProvider = _remoteTokenProvider;
 	if (!strongTokenProvider) {
-		PALog(@"KeychainTokenStore: ERROR: The store has no remote token provider. Returning invalid token error.");
+		PA2Log(@"KeychainTokenStore: ERROR: The store has no remote token provider. Returning invalid token error.");
 		completion(NO, [NSError errorWithDomain:PA2ErrorDomain code:PA2ErrorCodeInvalidToken userInfo:nil]);
 		return nil;
 	}
@@ -354,7 +354,7 @@ static void _synchronizedVoid(PA2PrivateTokenKeychainStore  * obj, void(^block)(
 		NSData * data = [tokenData serializedData];
 		if ([_keychain containsDataForKey:identifier]) {
 			// This is just warning, but creating two tokens with the same name at the same time, is not recommended.
-			PALog(@"KeychainTokenStore: WARNING: Looks like that token '%@' already has some data stored. Overwriting the content.", tokenData.name);
+			PA2Log(@"KeychainTokenStore: WARNING: Looks like that token '%@' already has some data stored. Overwriting the content.", tokenData.name);
 			[_keychain updateValue:data forKey:identifier];
 		} else {
 			[_keychain addValue:data forKey:identifier];
@@ -383,7 +383,7 @@ static void _synchronizedVoid(PA2PrivateTokenKeychainStore  * obj, void(^block)(
 			// the same token for multiple times. This may lead to situations, when you will not be able to remove all previously created tokens
 			// on the server.
 			// This warning is also displayed for removal and creation operations created at the same time.
-			PALog(@"TokenKeychainStore: WARNING: Looks like you're running simultaneous operations for token '%@'. This is highly not recommended.", name);
+			PA2Log(@"TokenKeychainStore: WARNING: Looks like you're running simultaneous operations for token '%@'. This is highly not recommended.", name);
 		} else {
 			[_pendingNamedOperations addObject:name];
 		}

--- a/proj-xcode/Classes/watch/PA2WCSessionManager+Private.h
+++ b/proj-xcode/Classes/watch/PA2WCSessionManager+Private.h
@@ -17,6 +17,7 @@
 #import "PA2WCSessionManager.h"
 #import "PA2WCSessionDataHandler.h"
 #import "PA2WCSessionPacket.h"
+#import "PA2Log.h"
 
 @interface PA2WCSessionManager (Private)
 

--- a/proj-xcode/Classes/watch/PA2WCSessionManager.m
+++ b/proj-xcode/Classes/watch/PA2WCSessionManager.m
@@ -165,12 +165,12 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
 {
 	NSDictionary * dict = [packet toDictionary];
 	if (!dict) {
-		PALog(@"PA2WCSessionManager: Cannon serialize packet to dictionary.");
+		PA2Log(@"PA2WCSessionManager: Cannon serialize packet to dictionary.");
 		return nil;
 	}
 	NSData * JSONData = [NSJSONSerialization dataWithJSONObject:dict options:0 error:NULL];
 	if (!JSONData) {
-		PALog(@"PA2WCSessionManager: Cannon serialize packet to JSON.");
+		PA2Log(@"PA2WCSessionManager: Cannon serialize packet to JSON.");
 		return nil;
 	}
 	NSMutableData * data = [NSMutableData dataWithCapacity:_HeaderSize + JSONData.length];
@@ -224,14 +224,14 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
 			if (!errorMessage) {
 				errorMessage = @"PA2WCSessionManager: Cannot create response packet.";
 			}
-			PALog(@"%@", errorMessage);
+			PA2Log(@"%@", errorMessage);
 			NSError * error = PA2MakeError(PA2ErrorCodeWatchConnectivity, errorMessage);
 			response = [PA2WCSessionPacket packetWithError:error];
 		}
 		replyHandler(_SerializePacket(response));
 	} else {
 		if (errorMessage) {
-			PALog(@"%@", errorMessage);
+			PA2Log(@"%@", errorMessage);
 		} else if (response.sendLazyResponseIfPossible) {
 			[self sendPacket:response];
 		}
@@ -328,7 +328,7 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
 {
 	// Validate input
 	if (withResponse && (completion == nil)) {
-		PALog(@"PA2WCSessionManager: Response is required but completion block is missing.");
+		PA2Log(@"PA2WCSessionManager: Response is required but completion block is missing.");
 		return;
 	}
 	
@@ -353,7 +353,7 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
 	if (!session) {
 		// On IOS, switch to debug build and check log what's the reason of unavailability.
 		// On watchOS, the session is typically not activated
-		PALog(@"PA2WCSessionManager: WCSession is currently not available for messaging.");
+		PA2Log(@"PA2WCSessionManager: WCSession is currently not available for messaging.");
 		if (completion) {
 			completion(nil, PA2MakeError(PA2ErrorCodeWatchConnectivity, @"PA2WCSessionManager: WCSession is currently not available for messaging."));
 		}
@@ -404,11 +404,11 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
 						ec == WCErrorCodeSessionNotActivated ||
 						ec == WCErrorCodeDeviceNotPaired ||
 						ec == WCErrorCodeWatchAppNotInstalled) {
-						PALog(@"PA2WCSessionManager: Message for target '%@' failed to deliver. Error: %@", request.target, error);
+						PA2Log(@"PA2WCSessionManager: Message for target '%@' failed to deliver. Error: %@", request.target, error);
 						return;
 					}
 				}
-				PALog(@"PA2WCSessionManager: Message for target '%@' failed to deliver, but we'll try transferUserInfo. Error: %@", request.target, error);
+				PA2Log(@"PA2WCSessionManager: Message for target '%@' failed to deliver, but we'll try transferUserInfo. Error: %@", request.target, error);
 				[session transferUserInfo: @{ PA2WCSessionPacket_USER_INFO_KEY : requestData }];
 			}];
 		} else {
@@ -439,7 +439,7 @@ static WCSession * _ValidateSession(WCSession * session)
 		if (session.activationState == WCSessionActivationStateActivated) {
 			return session;
 		} else {
-			PALog(@"PA2WCSessionManager: WCSession is not activated on this device.");
+			PA2Log(@"PA2WCSessionManager: WCSession is not activated on this device.");
 			return nil;
 		}
 	}
@@ -480,12 +480,12 @@ static WCSession * _ValidateSession(WCSession * session)
 	}
 #ifdef DEBUG
 	if (!session) {
-		PALog(@"PA2WCSessionManager: WCSession is not supported on this device.");
+		PA2Log(@"PA2WCSessionManager: WCSession is not supported on this device.");
 	} else {
 		if (!session.isPaired) {
-			PALog(@"PA2WCSessionManager: Warning: This device is not paired with Apple Watch.");
+			PA2Log(@"PA2WCSessionManager: Warning: This device is not paired with Apple Watch.");
 		} else {
-			PALog(@"PA2WCSessionManager: Warning: Watch App is not installed on the currently paired and active Apple Watch.");
+			PA2Log(@"PA2WCSessionManager: Warning: Watch App is not installed on the currently paired and active Apple Watch.");
 		}
 	}
 #endif // DEBUG

--- a/proj-xcode/Extensions/Common/PA2Log.h
+++ b/proj-xcode/Extensions/Common/PA2Log.h
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "PA2Macros.h"
+
+#pragma mark - Watch & Extensions SDK logging
+
+#if defined(DEBUG) && !defined(ENABLE_PA2_LOG)
+#define ENABLE_PA2_LOG
+#endif
+
+#ifdef DISABLE_PA2_LOG
+#warning DISABLE_PA2_LOG is no longer supported. Use PA2LogSetEnabled(NO) in runtime.
+#endif
+
+#ifdef ENABLE_PA2_LOG
+
+	// Implementations
+
+	PA2_EXTERN_C void PA2LogImpl(NSString * format, ...);
+
+	// Macros
+
+	/**
+	 PA2Log(...) macro prints a debug information into the debug console and is used internally
+	 in the PowerAuth SDK. For DEBUG builds, the macro is expanded to internal function which uses NSLog().
+	 For RELEASE builds, the message is completely suppressed during the compilation.
+	 */
+	#define PA2Log(...) 				PA2LogImpl(__VA_ARGS__)
+
+#else
+	// If PA2Log is disabled, then suppress whole log statement
+	#define PA2Log(...)
+
+#endif // ENABLE_PA2_LOG
+
+/**
+ Function enables or disables internal PowerAuth SDK logging.
+ Note that it's effective only when library is compiled in DEBUG build configuration.
+ */
+PA2_EXTERN_C void PA2LogSetEnabled(BOOL enabled);
+
+/**
+ Function returns YES if internal PowerAuth SDK logging is enabled.
+ Note that when library is compiled in RELEASE configuration, then always returns NO.
+ */
+PA2_EXTERN_C BOOL PA2LogIsEnabled(void);

--- a/proj-xcode/Extensions/Common/PA2Log.m
+++ b/proj-xcode/Extensions/Common/PA2Log.m
@@ -14,26 +14,37 @@
  * limitations under the License.
  */
 
-#import <UIKit/UIKit.h>
-
-//! Project version number for PowerAuth2.
-FOUNDATION_EXPORT double PowerAuth2VersionNumber;
-
-//! Project version string for PowerAuth2.
-FOUNDATION_EXPORT const unsigned char PowerAuth2VersionString[];
-
-#import "PowerAuthSDK.h"
-
-#import "PA2Client.h"
 #import "PA2Log.h"
-#import "PA2Macros.h"
-#import "PA2System.h"
-#import "PA2Keychain.h"
 
-#import "PA2ErrorConstants.h"
-#import "PA2PasswordUtil.h"
-#import "PA2Password.h"
-#import "PA2OtpUtil.h"
-#import "PA2ECIESEncryptor.h"
+#ifdef ENABLE_PA2_LOG
+static BOOL s_log_enabled = NO;
+void PA2LogImpl(NSString * format, ...)
+{
+	if (!s_log_enabled) {
+		return;
+	}
+	va_list args;
+	va_start(args, format);
+	NSString * message = [[NSString alloc] initWithFormat:format arguments:args];
+	va_end(args);
+	
+	NSLog(@"[PowerAuth] %@", message);
+}
+#endif // ENABLE_PA2_LOG
 
-#import "PA2WCSessionManager.h"
+
+void PA2LogSetEnabled(BOOL enabled)
+{
+#ifdef ENABLE_PA2_LOG
+	s_log_enabled = enabled;
+#endif
+}
+
+BOOL PA2LogIsEnabled(void)
+{
+#ifdef ENABLE_PA2_LOG
+	return s_log_enabled;
+#else
+	return NO;
+#endif
+}

--- a/proj-xcode/Extensions/IOS/PowerAuth2ForExtensions-umbrella.h
+++ b/proj-xcode/Extensions/IOS/PowerAuth2ForExtensions-umbrella.h
@@ -34,6 +34,7 @@ FOUNDATION_EXPORT const unsigned char PowerAuth2ForExtensionsVersionString[];
 
 // Import all public headers...
 #import "PA2Macros.h"
+#import "PA2Log.h"
 #import "PA2ErrorConstants.h"
 #import "PA2SessionStatusProvider.h"
 #import "PA2KeychainConfiguration.h"

--- a/proj-xcode/Extensions/IOS/PowerAuthExtensionSDK.m
+++ b/proj-xcode/Extensions/IOS/PowerAuthExtensionSDK.m
@@ -90,7 +90,7 @@
 		//	3. user install application again
 		//	4. user enables extension without running application for first time
 		// The result is that this function may return YES but the stored activation is not valid.
-		PALog(@"WARNING: Missing setup for PA2Keychain.keychainAttribute_UserDefaultsSuiteName.");
+		PA2Log(@"WARNING: Missing setup for PA2Keychain.keychainAttribute_UserDefaultsSuiteName.");
 	}
 	// Retrieve & investigate data stored in keychain
 	NSData *sessionData = [_statusKeychain dataForKey:_configuration.instanceId status:nil];

--- a/proj-xcode/Extensions/WatchOS/PowerAuth2ForWatch-umbrella.h
+++ b/proj-xcode/Extensions/WatchOS/PowerAuth2ForWatch-umbrella.h
@@ -34,6 +34,7 @@ FOUNDATION_EXPORT const unsigned char PowerAuth2ForWatchVersionString[];
 
 // Import all public headers...
 #import "PA2Macros.h"
+#import "PA2Log.h"
 #import "PA2ErrorConstants.h"
 #import "PA2SessionStatusProvider.h"
 #import "PA2KeychainConfiguration.h"

--- a/proj-xcode/Extensions/WatchOS/PowerAuthWatchSDK.m
+++ b/proj-xcode/Extensions/WatchOS/PowerAuthWatchSDK.m
@@ -112,7 +112,7 @@
 - (void) updateActivationStatusWithCompletion:(void(^ _Nonnull)(NSString * _Nullable activationId, NSError * _Nullable error))completion
 {
 	if (!completion) {
-		PALog(@"PowerAuthWatchSDK::updateActivationStatusWithCompletion: Missing completion block.");
+		PA2Log(@"PowerAuthWatchSDK::updateActivationStatusWithCompletion: Missing completion block.");
 		return;
 	}
 	PA2WCSessionPacket * request = [self requestStatusPacket];

--- a/proj-xcode/Extensions/WatchOS/private/PA2WatchSynchronizationService.m
+++ b/proj-xcode/Extensions/WatchOS/private/PA2WatchSynchronizationService.m
@@ -78,18 +78,18 @@
 			if (currentData) {
 				if (![currentData isEqualToData:activationIdData]) {
 					[_statusKeychain updateValue:activationIdData forKey:sessionInstanceId];
-					PALog(@"PA2WatchSynchronizationService: Session with instanceId '%@' is now activated (with different activation ID).", sessionInstanceId);
+					PA2Log(@"PA2WatchSynchronizationService: Session with instanceId '%@' is now activated (with different activation ID).", sessionInstanceId);
 					removeAssociatedTokens = YES;
 				}
 			} else {
 				[_statusKeychain addValue:activationIdData forKey:sessionInstanceId];
-				PALog(@"PA2WatchSynchronizationService: Session with instanceId '%@' is now activated.", sessionInstanceId);
+				PA2Log(@"PA2WatchSynchronizationService: Session with instanceId '%@' is now activated.", sessionInstanceId);
 			}
 		} else {
 			// Removing activation status
 			if (currentData) {
 				[_statusKeychain deleteDataForKey:sessionInstanceId];
-				PALog(@"PA2WatchSynchronizationService: Session with instanceId '%@' is no longer activated.", sessionInstanceId);
+				PA2Log(@"PA2WatchSynchronizationService: Session with instanceId '%@' is no longer activated.", sessionInstanceId);
 			}
 			removeAssociatedTokens = YES;
 		}
@@ -98,7 +98,7 @@
 			[self removeAllTokensForInstanceId:sessionInstanceId];
 		}
 	} else {
-		PALog(@"PA2WatchSynchronizationService: ERROR: Session's instanceId is empty.");
+		PA2Log(@"PA2WatchSynchronizationService: ERROR: Session's instanceId is empty.");
 	}
 }
 
@@ -106,7 +106,7 @@
 
 - (void) removeAllTokensForInstanceId:(NSString*)instanceId
 {
-	PALog(@"PA2WatchSynchronizationService: Removing all tokens for instanceId '%@'", instanceId);
+	PA2Log(@"PA2WatchSynchronizationService: Removing all tokens for instanceId '%@'", instanceId);
 	PA2Keychain * keychain = [[PA2Keychain alloc] initWithIdentifier:instanceId];
 	NSString * keychainPrefix = [PA2PrivateTokenKeychainStore keychainPrefixForInstanceId:instanceId];
 	[[keychain allItems] enumerateKeysAndObjectsUsingBlock:^(NSString * identifier, id foo, BOOL * stop) {

--- a/proj-xcode/PowerAuthCore.xcodeproj/project.pbxproj
+++ b/proj-xcode/PowerAuthCore.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		BFC92DF02073E3860087851C /* pa2CryptoAESTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF99D8C22073E00D00735ED2 /* pa2CryptoAESTests.cpp */; };
 		BFC92DF12073E3860087851C /* pa2CryptoHMACTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF99D8BD2073E00D00735ED2 /* pa2CryptoHMACTests.cpp */; };
 		BFC92DF22073E3860087851C /* pa2CryptoECDHKDFTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF99D8C82073E00D00735ED2 /* pa2CryptoECDHKDFTests.cpp */; };
+		BFDFED8F20BEED3D0094138A /* PA2CoreLog.m in Sources */ = {isa = PBXBuildFile; fileRef = BFDFED8E20BEED3D0094138A /* PA2CoreLog.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -227,6 +228,8 @@
 		BFB47D3120753359008A6A52 /* PA2PrivateImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PA2PrivateImpl.h; sourceTree = "<group>"; };
 		BFB47D3D207533E6008A6A52 /* PA2PrivateCrypto_Ext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PA2PrivateCrypto_Ext.m; sourceTree = "<group>"; };
 		BFB47D3E20753444008A6A52 /* cc7.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = cc7.xcodeproj; path = "../cc7/proj-xcode/cc7.xcodeproj"; sourceTree = "<group>"; };
+		BFDFED8D20BEED3D0094138A /* PA2CoreLog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PA2CoreLog.h; sourceTree = "<group>"; };
+		BFDFED8E20BEED3D0094138A /* PA2CoreLog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PA2CoreLog.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -495,6 +498,8 @@
 				BFB47D2F20753359008A6A52 /* PA2Types.h */,
 				BFB47D2920753359008A6A52 /* PA2Types.mm */,
 				BFB47D2A20753359008A6A52 /* PA2Macros.h */,
+				BFDFED8D20BEED3D0094138A /* PA2CoreLog.h */,
+				BFDFED8E20BEED3D0094138A /* PA2CoreLog.m */,
 				BFB47D1E20753359008A6A52 /* PA2PrivateMacros.h */,
 				BFB47D2C20753359008A6A52 /* PA2PrivateMacros.m */,
 				BFB47D2D20753359008A6A52 /* PA2ErrorConstants.h */,
@@ -661,6 +666,7 @@
 				BFB47D362075335A008A6A52 /* PA2Session.mm in Sources */,
 				BF99D90E2073E15100735ED2 /* Hash.cpp in Sources */,
 				BF99D90C2073E15100735ED2 /* ECC.cpp in Sources */,
+				BFDFED8F20BEED3D0094138A /* PA2CoreLog.m in Sources */,
 				BF99D9062073E14100735ED2 /* ECIES.cpp in Sources */,
 				BFB47D342075335A008A6A52 /* PA2ErrorConstants.m in Sources */,
 				BFB47D352075335A008A6A52 /* PA2Encryptor.mm in Sources */,

--- a/proj-xcode/PowerAuthExtensionSdk.xcodeproj/project.pbxproj
+++ b/proj-xcode/PowerAuthExtensionSdk.xcodeproj/project.pbxproj
@@ -94,6 +94,10 @@
 		BFA0E2D9200FB5600011F0A6 /* PA2WeakArray.h in Headers */ = {isa = PBXBuildFile; fileRef = BFA0E2D7200FB5600011F0A6 /* PA2WeakArray.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BFA0E2DA200FB5600011F0A6 /* PA2WeakArray.m in Sources */ = {isa = PBXBuildFile; fileRef = BFA0E2D8200FB5600011F0A6 /* PA2WeakArray.m */; };
 		BFA0E2DE200FCF710011F0A6 /* PA2WCSessionManager_WatchServices.m in Sources */ = {isa = PBXBuildFile; fileRef = BFA0E2DD200FCF710011F0A6 /* PA2WCSessionManager_WatchServices.m */; };
+		BFDFEDA920BEF6D30094138A /* PA2Log.h in Headers */ = {isa = PBXBuildFile; fileRef = BFDFEDA720BEF6D30094138A /* PA2Log.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFDFEDAA20BEF6D30094138A /* PA2Log.h in Headers */ = {isa = PBXBuildFile; fileRef = BFDFEDA720BEF6D30094138A /* PA2Log.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFDFEDAB20BEF6D30094138A /* PA2Log.m in Sources */ = {isa = PBXBuildFile; fileRef = BFDFEDA820BEF6D30094138A /* PA2Log.m */; };
+		BFDFEDAC20BEF6D30094138A /* PA2Log.m in Sources */ = {isa = PBXBuildFile; fileRef = BFDFEDA820BEF6D30094138A /* PA2Log.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -162,6 +166,8 @@
 		BFCEF4852023A23A00C14EC1 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BFCEF4882023AA5C00C14EC1 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BFCEF4892023AA5C00C14EC1 /* PowerAuth2ForWatch.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = PowerAuth2ForWatch.modulemap; sourceTree = "<group>"; };
+		BFDFEDA720BEF6D30094138A /* PA2Log.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PA2Log.h; sourceTree = "<group>"; };
+		BFDFEDA820BEF6D30094138A /* PA2Log.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PA2Log.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -190,6 +196,8 @@
 				BF0EBED91FE166B700E97918 /* Private */,
 				BF8C30362004E20000EAF830 /* PA2ExtensionLibrary.h */,
 				BF8C30372004E20000EAF830 /* PA2ExtensionLibrary.m */,
+				BFDFEDA720BEF6D30094138A /* PA2Log.h */,
+				BFDFEDA820BEF6D30094138A /* PA2Log.m */,
 			);
 			name = Common;
 			path = Extensions/Common;
@@ -420,6 +428,7 @@
 				BF54920D1FFFC6FE0036DB9E /* PowerAuthToken.h in Headers */,
 				BF5492121FFFC7170036DB9E /* PA2AuthorizationHttpHeader.h in Headers */,
 				BF5492131FFFC7210036DB9E /* PowerAuthExtensionSDK.h in Headers */,
+				BFDFEDA920BEF6D30094138A /* PA2Log.h in Headers */,
 				BF5492141FFFC7860036DB9E /* PowerAuth2ForExtensions-umbrella.h in Headers */,
 				BF5492071FFFC6DB0036DB9E /* PA2PrivateMacros.h in Headers */,
 				BF5492081FFFC6DF0036DB9E /* PA2PrivateCrypto.h in Headers */,
@@ -456,6 +465,7 @@
 				BFA0E28A200CF48B0011F0A6 /* PA2PrivateTokenData.h in Headers */,
 				BFA0E2CA200E65D70011F0A6 /* PA2WCSessionPacket_ActivationStatus.h in Headers */,
 				BFA0E2A8200D12990011F0A6 /* PA2WCSessionManager.h in Headers */,
+				BFDFEDAA20BEF6D30094138A /* PA2Log.h in Headers */,
 				BFA0E28E200CF49B0011F0A6 /* PA2PrivateTokenKeychainStore.h in Headers */,
 				BFA0E2CB200E65D70011F0A6 /* PA2WCSessionPacket_Constants.h in Headers */,
 				BFA0E27B200CF4290011F0A6 /* PA2SessionStatusProvider.h in Headers */,
@@ -566,6 +576,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BF5491E91FFFBAC60036DB9E /* PA2PrivateTokenData.m in Sources */,
+				BFDFEDAB20BEF6D30094138A /* PA2Log.m in Sources */,
 				BF5491FF1FFFC1770036DB9E /* PowerAuthExtensionSDK.m in Sources */,
 				BF5491E41FFFBAB70036DB9E /* PA2KeychainConfiguration.m in Sources */,
 				BF5491E21FFFBAAF0036DB9E /* PA2PrivateMacros.m in Sources */,
@@ -602,6 +613,7 @@
 				BF8E4F002010DC7800010B74 /* PA2WatchRemoteTokenProvider.m in Sources */,
 				BFA0E276200CF3D60011F0A6 /* PA2ExtensionLibrary.m in Sources */,
 				BFA0E28B200CF4900011F0A6 /* PA2PrivateTokenData.m in Sources */,
+				BFDFEDAC20BEF6D30094138A /* PA2Log.m in Sources */,
 				BFA0E27D200CF43E0011F0A6 /* PA2PrivateMacros.m in Sources */,
 				BFA0E2DA200FB5600011F0A6 /* PA2WeakArray.m in Sources */,
 				BFA0E2D2200FA1D30011F0A6 /* PA2WatchSynchronizationService.m in Sources */,

--- a/proj-xcode/PowerAuthLib.xcodeproj/project.pbxproj
+++ b/proj-xcode/PowerAuthLib.xcodeproj/project.pbxproj
@@ -149,6 +149,9 @@
 		BFB47D6C207536B1008A6A52 /* libPowerAuthCoreTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BFB47D6420753640008A6A52 /* libPowerAuthCoreTests.a */; };
 		BFD386621F2B528600F74FF9 /* TestConfig in Resources */ = {isa = PBXBuildFile; fileRef = BFD386611F2B528600F74FF9 /* TestConfig */; };
 		BFD386671F2B6BE700F74FF9 /* PowerAuthTestServerConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = BFD386661F2B6BE700F74FF9 /* PowerAuthTestServerConfig.m */; };
+		BFDFED9520BEEF730094138A /* PA2CoreLog.h in Headers */ = {isa = PBXBuildFile; fileRef = BFDFED9420BEEF730094138A /* PA2CoreLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFDFED9820BEEFAC0094138A /* PA2Log.h in Headers */ = {isa = PBXBuildFile; fileRef = BFDFED9620BEEFAC0094138A /* PA2Log.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFDFED9920BEEFAC0094138A /* PA2Log.m in Sources */ = {isa = PBXBuildFile; fileRef = BFDFED9720BEEFAC0094138A /* PA2Log.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -352,6 +355,9 @@
 		BFD386611F2B528600F74FF9 /* TestConfig */ = {isa = PBXFileReference; lastKnownFileType = folder; path = TestConfig; sourceTree = SOURCE_ROOT; };
 		BFD386651F2B6BE700F74FF9 /* PowerAuthTestServerConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PowerAuthTestServerConfig.h; sourceTree = "<group>"; };
 		BFD386661F2B6BE700F74FF9 /* PowerAuthTestServerConfig.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PowerAuthTestServerConfig.m; sourceTree = "<group>"; };
+		BFDFED9420BEEF730094138A /* PA2CoreLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PA2CoreLog.h; sourceTree = "<group>"; };
+		BFDFED9620BEEFAC0094138A /* PA2Log.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PA2Log.h; sourceTree = "<group>"; };
+		BFDFED9720BEEFAC0094138A /* PA2Log.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PA2Log.m; sourceTree = "<group>"; };
 		BFE5DBCA1FB3908E00A4FBAB /* PA2ECIESEncryptor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PA2ECIESEncryptor.h; sourceTree = "<group>"; };
 		BFF9CE091F07DC34001C892B /* PA2ActivationResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PA2ActivationResult.h; sourceTree = "<group>"; };
 		BFF9CE0A1F07DC34001C892B /* PA2ActivationResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PA2ActivationResult.m; sourceTree = "<group>"; };
@@ -464,6 +470,7 @@
 				BF30176D1FE027A20099B253 /* PA2SessionStatusProvider.h */,
 				1B2EEF321D662AB10039D92A /* PA2Types.h */,
 				1B6F00051D6DCDA700EC1C5A /* PA2Macros.h */,
+				BFDFED9420BEEF730094138A /* PA2CoreLog.h */,
 				1B7A3A531D8FCC0D002D1043 /* PA2PrivateMacros.h */,
 				1B9AD2B61DA448D600CF52C9 /* PA2ErrorConstants.h */,
 				BFE5DBCA1FB3908E00A4FBAB /* PA2ECIESEncryptor.h */,
@@ -586,6 +593,8 @@
 			children = (
 				1BFD687A1D742C1C00B08338 /* PA2System.h */,
 				1BFD687B1D742C1C00B08338 /* PA2System.m */,
+				BFDFED9620BEEFAC0094138A /* PA2Log.h */,
+				BFDFED9720BEEFAC0094138A /* PA2Log.m */,
 			);
 			path = system;
 			sourceTree = "<group>";
@@ -835,6 +844,7 @@
 				BF8CF4ED2032EB41002A6B6E /* PA2ActivationResult.h in Headers */,
 				BF8CF4EE2032EB41002A6B6E /* PA2PrivateNetworking.h in Headers */,
 				BF8CF4EF2032EB41002A6B6E /* PA2EncryptedRequest.h in Headers */,
+				BFDFED9520BEEF730094138A /* PA2CoreLog.h in Headers */,
 				BF8CF4F02032EB41002A6B6E /* PA2VaultUnlockResponse.h in Headers */,
 				BF8CF4F12032EB41002A6B6E /* PA2Session.h in Headers */,
 				BF8CF4F22032EB41002A6B6E /* PA2PrivateHttpTokenProvider.h in Headers */,
@@ -842,6 +852,7 @@
 				BF8CF4F42032EB41002A6B6E /* PA2ClientSslValidationStrategy.h in Headers */,
 				BF8CF4F52032EB41002A6B6E /* PA2Keychain.h in Headers */,
 				BF8CF4F62032EB41002A6B6E /* PowerAuthConfiguration.h in Headers */,
+				BFDFED9820BEEFAC0094138A /* PA2Log.h in Headers */,
 				BF8CF4F72032EB41002A6B6E /* PA2WCSessionPacket.h in Headers */,
 				BF8CF4F82032EB41002A6B6E /* PowerAuthAuthentication.h in Headers */,
 				BF61F90C20768BBC00520C57 /* PA2OtpUtil.h in Headers */,
@@ -1065,6 +1076,7 @@
 				BF8CF4C02032EB41002A6B6E /* PA2EncryptedRequest.m in Sources */,
 				BF30DB5D206CEAE900430C12 /* PA2VaultUnlockRequest.m in Sources */,
 				BF8CF4C12032EB41002A6B6E /* PA2OperationTask.m in Sources */,
+				BFDFED9920BEEFAC0094138A /* PA2Log.m in Sources */,
 				BF8CF4C32032EB41002A6B6E /* PA2WCSessionManager_IOSServices.m in Sources */,
 				BF8CF4C52032EB41002A6B6E /* PA2Client.m in Sources */,
 				BF8CF4C62032EB41002A6B6E /* PA2AuthorizationHttpHeader.m in Sources */,

--- a/proj-xcode/TestClasses/PowerAuthConcurrencyTests.m
+++ b/proj-xcode/TestClasses/PowerAuthConcurrencyTests.m
@@ -20,7 +20,7 @@
 #import "AsyncHelper.h"
 #import "FakePowerAuthTokenStore.h"
 
-#import "PowerAuthSDK.h"
+#import "PowerAuth2.h"
 
 /**
  The `PowerAuthTokenTests` test class is similar to `PowerAuthSDKTests`
@@ -82,6 +82,8 @@
  */
 - (void) runOnceForAllTests
 {
+	PA2LogSetEnabled(YES);
+	
 	if (_hasConfig || _invalidConfig) {
 		return;
 	}

--- a/proj-xcode/TestClasses/PowerAuthSDKTests.m
+++ b/proj-xcode/TestClasses/PowerAuthSDKTests.m
@@ -86,6 +86,8 @@ static NSString * PA_Ver = @"2.1";
  */
 - (void) runOnceForAllTests
 {
+	PA2LogSetEnabled(YES);
+	
 	if (_hasConfig || _invalidConfig) {
 		return;
 	}

--- a/proj-xcode/TestClasses/PowerAuthTokenTests.m
+++ b/proj-xcode/TestClasses/PowerAuthTokenTests.m
@@ -20,7 +20,7 @@
 #import "AsyncHelper.h"
 #import "FakePowerAuthTokenStore.h"
 
-#import "PowerAuthSDK.h"
+#import "PowerAuth2.h"
 
 /**
  The `PowerAuthTokenTests` test class is similar to `PowerAuthSDKTests`
@@ -82,6 +82,8 @@
  */
 - (void) runOnceForAllTests
 {
+	PA2LogSetEnabled(YES);
+	
 	if (_hasConfig || _invalidConfig) {
 		return;
 	}


### PR DESCRIPTION
This change brings runtime configurable logging to IOS SDK:
- For high level codes, `PALog` macro was replaced with `PA2Log`
- For PowerAuthCore, `PALog` macro was replaced with `PA2CoreLog`
- For Watch & Extensions, `PALog` was replaced with `PA2Log`, but with slightly different implementation (there's no core lib or cc7 on background)
- Added `PA2LogSetEnabled(bool)` & `bool PA2LogIsEnabled()` functions to control logging to all SDKs. Both functions are effective only in DEBUG build configuration.
- Added `PA2CriticalWarning()` function to print warning, which cannot be suppressed (like disabling SSL)