### PR TITLE
IOS: Fixed #121: Added NS_NOESCAPE annotation to objc interfaces with non-escaping closures.

### DIFF
--- a/proj-xcode/Classes/core/PA2ECIESEncryptor.h
+++ b/proj-xcode/Classes/core/PA2ECIESEncryptor.h
@@ -114,7 +114,7 @@
  Returns YES if encryption succeeded or NO in case of error.
  */
 - (BOOL) encryptRequest:(nullable NSData *)data
-			 completion:(void (^_Nonnull)(PA2ECIESCryptogram * _Nullable cryptogram, PA2ECIESEncryptor * _Nullable decryptor))completion;
+			 completion:(void (NS_NOESCAPE ^_Nonnull)(PA2ECIESCryptogram * _Nullable cryptogram, PA2ECIESEncryptor * _Nullable decryptor))completion;
 
 @end
 

--- a/proj-xcode/Classes/core/PA2Password.h
+++ b/proj-xcode/Classes/core/PA2Password.h
@@ -102,7 +102,7 @@
  
  Returns NO if passphrase is empty, or result returned from the block.
  */
-- (BOOL) validatePasswordComplexity:(BOOL (^_Nullable)(const UInt8 * _Nonnull  passphrase, NSUInteger length))validationBlock;
+- (BOOL) validatePasswordComplexity:(BOOL (NS_NOESCAPE ^_Nullable)(const UInt8 * _Nonnull  passphrase, NSUInteger length))validationBlock;
 
 @end
 

--- a/proj-xcode/Classes/core/PA2WeakArray.h
+++ b/proj-xcode/Classes/core/PA2WeakArray.h
@@ -54,12 +54,12 @@
  At first, removes all nil references from underlying array and then enumerates over all
  still valid objects.
  */
-- (void) enumerateWeakObjectsUsingBlock:(void (^_Nonnull)(ObjectType _Nonnull item, BOOL * _Nonnull stop))block;
+- (void) enumerateWeakObjectsUsingBlock:(void (NS_NOESCAPE ^_Nonnull)(ObjectType _Nonnull item, BOOL * _Nonnull stop))block;
 /**
  At first, removes all nil references from underlying array and then calls block for each still valid object.
  The enumeration stops when block returns YES and the last enumerated object is returned.
  */
-- (nullable ObjectType) findObjectUsingBlock:(BOOL (^_Nonnull)(ObjectType _Nonnull item))block;
+- (nullable ObjectType) findObjectUsingBlock:(BOOL (NS_NOESCAPE ^_Nonnull)(ObjectType _Nonnull item))block;
 /**
  At first, removes all nil references from underlying array and then returns all still valid objects in
  strong referenced array.


### PR DESCRIPTION
This PR has no functional changes. Just improves our SDK's interoperability with swift

Fixes #121 