### PR TITLE
Android: Fixed #120: Add ProGuard config to the aar library

### DIFF
--- a/proj-android/PowerAuthLibrary/build.gradle
+++ b/proj-android/PowerAuthLibrary/build.gradle
@@ -33,7 +33,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'proguard-rules.pro'
         }
     }
 

--- a/proj-android/PowerAuthLibrary/proguard-rules.pro
+++ b/proj-android/PowerAuthLibrary/proguard-rules.pro
@@ -1,17 +1,32 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /Users/miroslavmichalec/Android/sdk/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
+# Copyright 2017 Lime - HighTech Solutions s.r.o.
 #
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# Add any project specific keep options here:
+-keepattributes Signature
+-keepattributes *Annotation*
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+-keep class io.getlime.security.powerauth.core.* {
+    <fields>;
+}
+-keep class io.getlime.security.powerauth.sdk.impl.PowerAuthPrivateTokenData {
+    <fields>;
+}
+-keep class io.getlime.security.powerauth.util.otp.Otp {
+    <fields>;
+}
+-keepclassmembers class io.getlime.core.rest.model.** {
+    <fields>;
+}
+-keepclassmembers class io.getlime.security.powerauth.rest.api.model.** {
+    <fields>;
+}


### PR DESCRIPTION
Configuration is packaged into the aar library to be used when the app
is built. The configuration is minimal to allow reasonable
app obfuscation while keeping it working.