### PR TITLE
IOS: Provide more info about biometry and its status on the system

### DIFF
--- a/proj-xcode/Classes/keychain/PA2Keychain.h
+++ b/proj-xcode/Classes/keychain/PA2Keychain.h
@@ -71,7 +71,7 @@ typedef NS_ENUM(int, PA2BiometricAuthenticationStatus) {
 	PA2BiometricAuthenticationStatus_NotEnrolled,
 	/**
 	 Biometric authentication is supported, but too many failed attempts caused its lockout.
-	 User has authenticate with the password or passcode.
+	 User has to authenticate with the password or passcode.
 	 */
 	PA2BiometricAuthenticationStatus_Lockout,
 	/**
@@ -82,7 +82,7 @@ typedef NS_ENUM(int, PA2BiometricAuthenticationStatus) {
 
 /**
  The PA2BiometricAuthenticationInfo structure contains information about
- supported biometry and its current status on the system.
+ supported type of biometry and its current status on the system.
  */
 typedef struct PA2BiometricAuthenticationInfo {
 	/**
@@ -90,7 +90,7 @@ typedef struct PA2BiometricAuthenticationInfo {
 	 */
 	PA2BiometricAuthenticationStatus currentStatus;
 	/**
-	 Type of supported biometric authentication the system.
+	 Type of supported biometric authentication on the system.
 	 */
 	PA2BiometricAuthenticationType biometryType;
 	

--- a/proj-xcode/Classes/keychain/PA2Keychain.h
+++ b/proj-xcode/Classes/keychain/PA2Keychain.h
@@ -30,20 +30,71 @@ typedef NS_ENUM(int, PA2KeychainStoreItemResult) {
 /**
  Enum encapsulating supported biometric authentication types.
  */
-typedef NS_ENUM(int, PA2SupportedBiometricAuthentication) {
+typedef NS_ENUM(int, PA2BiometricAuthenticationType) {
 	/**
 	 Biometric authentication is not supported on the current system.
 	 */
-	PA2SupportedBiometricAuthentication_None,
+	PA2BiometricAuthenticationType_None,
 	/**
 	 Touch ID is supported on the current system.
 	 */
-	PA2SupportedBiometricAuthentication_TouchID,
+	PA2BiometricAuthenticationType_TouchID,
 	/**
 	 Face ID is supported on the current system.
 	 */
-	PA2SupportedBiometricAuthentication_FaceID,
+	PA2BiometricAuthenticationType_FaceID,
 };
+
+/**
+ The PA2SupportedBiometricAuthentication is deprecated since SDK version 0.19.
+ You can use PA2BiometricAuthenticationType as a full replacement.
+ */
+typedef PA2BiometricAuthenticationType PA2SupportedBiometricAuthentication PA2_DEPRECATED(0.19);
+
+/**
+ Enum encapsulating status of biometric authentication on the system.
+ */
+typedef NS_ENUM(int, PA2BiometricAuthenticationStatus) {
+	/**
+	 Biometric authentication is not present on the system
+	 */
+	PA2BiometricAuthenticationStatus_NotSupported,
+	/**
+	 Biometric authentication is available on the system, but for an unknown
+	 reason is not available right now. This may happen on iOS 11+, when an
+	 unknown error is returned from `LAContext.canEvaluatePolicy()`.
+	 */
+	PA2BiometricAuthenticationStatus_NotAvailable,
+	/**
+	 Biometric authentication is supported, but not enrolled on the system.
+	 */
+	PA2BiometricAuthenticationStatus_NotEnrolled,
+	/**
+	 Biometric authentication is supported, but too many failed attempts caused its lockout.
+	 User has authenticate with the password or passcode.
+	 */
+	PA2BiometricAuthenticationStatus_Lockout,
+	/**
+	 Biometric authentication is supported and can be evaluated on the system.
+	 */
+	PA2BiometricAuthenticationStatus_Available,
+};
+
+/**
+ The PA2BiometricAuthenticationInfo structure contains information about
+ supported biometry and its current status on the system.
+ */
+typedef struct PA2BiometricAuthenticationInfo {
+	/**
+	 Current status of supported biometry on the system.
+	 */
+	PA2BiometricAuthenticationStatus currentStatus;
+	/**
+	 Type of supported biometric authentication the system.
+	 */
+	PA2BiometricAuthenticationType biometryType;
+	
+} PA2BiometricAuthenticationInfo;
 
 
 /** Simple wrapper on top of an iOS Keychain.
@@ -258,14 +309,30 @@ typedef NS_ENUM(int, PA2SupportedBiometricAuthentication) {
 
 /**
  Convenience static property that checks if Touch ID or Face ID can be used on the current system.
+ 
+ Note that the property contains "NO" also if biometry is not enrolled or if it has been locked down. To distinguish between
+ an availability and lockdown you can use `biometricAuthenticationInfo` static property.
+ 
  @return YES if biometry can be used (iOS 9.0+), NO otherwise. On watchOS or iOS App Extensions always returns NO.
  */
 @property (class, readonly) BOOL canUseBiometricAuthentication;
 
 /**
  Convenience static property that returns supported biometry on the current system.
+ 
+ Note that the property contains "None" also if biometry is not enrolled or if it has been locked down. To distinguish between
+ an availability and lockdown you can use `biometricAuthenticationInfo` static property.
+ 
  @return Type of supported biometric authentication on current system. On watchOS or iOS App Extensions always returns None.
  */
-@property (class, readonly) PA2SupportedBiometricAuthentication supportedBiometricAuthentication;
+@property (class, readonly) PA2BiometricAuthenticationType supportedBiometricAuthentication;
+
+/**
+ Static property that returns full information about biometry on the system. The resturned structure contains
+ information about supported type (Touch ID or Face ID) and also actual biometry status (N/A, not enrolled, etc..).
+ 
+ @return Structure containing full information about current supported biometry and its status on the system.
+ */
+@property (class, readonly) PA2BiometricAuthenticationInfo biometricAuthenticationInfo;
 
 @end

--- a/proj-xcode/Classes/keychain/PA2Keychain.m
+++ b/proj-xcode/Classes/keychain/PA2Keychain.m
@@ -264,33 +264,112 @@ static void _AddUseNoAuthenticationUI(NSMutableDictionary * query)
 
 #pragma mark - Biometry support
 
-+ (BOOL) canUseBiometricAuthentication
-{
-	return [self supportedBiometricAuthentication] != PA2SupportedBiometricAuthentication_None;
-}
+/**
+ Looks like Apple introduced a new biometry type. We should try to continue,
+ and pretend that TouchID is available. Application's UI will probably display
+ wrong information, but at least it may work.
+ */
+#define __BiometricAuthenticationType_Fallback 	PA2BiometricAuthenticationType_TouchID
 
-+ (PA2SupportedBiometricAuthentication) supportedBiometricAuthentication
+/**
+ A private function returns full information about biometric support on the system. The method internally
+ uses `LAContext.canEvaluatePolicy()`.
+ */
+static PA2BiometricAuthenticationInfo _getBiometryInfo()
 {
+	PA2BiometricAuthenticationInfo info = { PA2BiometricAuthenticationStatus_NotSupported, PA2BiometricAuthenticationType_None };
 #if !defined(PA2_EXTENSION_SDK)
 	// Check is available only for regular iOS applications
 	if (@available(iOS 9, *)) {
 		LAContext * context = [[LAContext alloc] init];
-		BOOL canEvaluate = [context canEvaluatePolicy:kLAPolicyDeviceOwnerAuthenticationWithBiometrics error:nil];
+		NSError * error = nil;
+		BOOL canEvaluate = [context canEvaluatePolicy:kLAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error];
 		if (canEvaluate) {
+			// If we can evaluate, then everything is quite simple.
+			info.currentStatus = PA2BiometricAuthenticationStatus_Available;
+			// Now check the type of biometry
 			if (@available(iOS 11.0, *)) {
 				LABiometryType bt = context.biometryType;
 				if (bt == LABiometryTypeTouchID) {
-					return PA2SupportedBiometricAuthentication_TouchID;
+					info.biometryType = PA2BiometricAuthenticationType_TouchID;
 				} else if (bt == LABiometryTypeFaceID) {
-					return PA2SupportedBiometricAuthentication_FaceID;
+					info.biometryType = PA2BiometricAuthenticationType_FaceID;
+				} else {
+					// Check comment above "__BiometricAuthenticationType_Fallback" for details.
+					PA2Log(@"Warning: LAContext.biometryType contains unknown biometryType %@.", @(bt));
+					info.biometryType = __BiometricAuthenticationType_Fallback;
+				}
+			} else {
+				// No FaceID before iOS11, so it has to be TouchID
+				info.biometryType = PA2BiometricAuthenticationType_TouchID;
+			}
+			//
+		} else {
+			// In case of error we cannot evaluate, but the type of biometry can be determined.
+			NSInteger code = [error.domain isEqualToString:LAErrorDomain] ? error.code : 0;
+			if (@available(iOS 11.0, *)) {
+				// On iOS 11 its quite simple, we have type property available and status can be determied
+				// from the error.
+				LABiometryType bt = context.biometryType;
+				// The short living LABiometryNone was introduced in IOS 11.0 and deprecated in 11.2 :D
+				// Following condition will probably cause a warning in future SDKs. If this happens, then we
+				// can safely use the 0 constant, because the new LABiometryTypeNone requires targeting IOS 11.2+,
+				// and that's not acceptable. Both constants are equal to 0...
+				if (bt != LABiometryNone) {
+					if (bt == LABiometryTypeTouchID) {
+						info.biometryType  = PA2BiometricAuthenticationType_TouchID;
+					} else if (bt == LABiometryTypeFaceID) {
+						info.biometryType  = PA2BiometricAuthenticationType_FaceID;
+					} else {
+						// Check comment above "__BiometricAuthenticationType_Fallback" for details.
+						PA2Log(@"Warning: LAContext.biometryType contains unknown biometryType %@.", @(bt));
+						info.biometryType = __BiometricAuthenticationType_Fallback;
+					}
+					if (code == LAErrorBiometryLockout) {
+						info.currentStatus = PA2BiometricAuthenticationStatus_Lockout;
+					} else if (code == LAErrorBiometryNotEnrolled) {
+						info.currentStatus = PA2BiometricAuthenticationStatus_NotEnrolled;
+					} else {
+						// The biometry is available, but returned error is unknown.
+						PA2Log(@"LAContext.canEvaluatePolicy() failed with error: %@", error);
+						info.currentStatus = PA2BiometricAuthenticationStatus_NotAvailable;
+					}
+				}
+			} else {
+				// On older systems (IOS 8..10), only Touch ID is available.
+				if (code == LAErrorTouchIDLockout) {
+					info.currentStatus = PA2BiometricAuthenticationStatus_Lockout;
+					info.biometryType  = PA2BiometricAuthenticationType_TouchID;
+				} else if (code == LAErrorTouchIDNotEnrolled) {
+					info.currentStatus = PA2BiometricAuthenticationStatus_NotEnrolled;
+					info.biometryType  = PA2BiometricAuthenticationType_TouchID;
 				}
 			}
-			// No Face ID before iOS11
-			return PA2SupportedBiometricAuthentication_TouchID;
 		}
 	}
 #endif // !defined(PA2_EXTENSION_SDK)
-	return PA2SupportedBiometricAuthentication_None;
+	return info;
+}
+
++ (BOOL) canUseBiometricAuthentication
+{
+	// The behavior of this property is that it returns YES, only if biometry policy can be evaluated.
+	return _getBiometryInfo().currentStatus == PA2BiometricAuthenticationStatus_Available;
+}
+
++ (PA2BiometricAuthenticationType) supportedBiometricAuthentication
+{
+	PA2BiometricAuthenticationInfo info = _getBiometryInfo();
+	// The behavior of this property is that if the biometry policy cannot be evaluated, then returns "None".
+	if (info.currentStatus == PA2BiometricAuthenticationStatus_Available) {
+		return info.biometryType;
+	}
+	return PA2BiometricAuthenticationType_None;
+}
+
++ (PA2BiometricAuthenticationInfo) biometricAuthenticationInfo
+{
+	return _getBiometryInfo();
 }
 
 


### PR DESCRIPTION
This PR brings following changes:

- `PA2SupportedBiometricAuthentication` is now deprecated and the replacement is `PA2BiometricAuthenticationType`
- added `PA2BiometricAuthenticationStatus` covering all possible states of biometry authentication
- added `struct PA2BiometricAuthenticationInfo` wrapping both "status" and "type" enumerations.
- added `PA2Keychain.biometricAuthenticationInfo` class property

Behavior of `PA2Keychain.canUseBiometricAuthentication` and `PA2Keychain. supportedBiometricAuthentication` should be the same as before.

Fixes #125 